### PR TITLE
feat!: add description field to org queries

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -183,9 +183,12 @@ components:
       type: object
       required:
         - schemaName
+        - description
         - pipeline
       properties:
         schemaName:
+          type: string
+        description:
           type: string
         pipeline:
           type: array

--- a/src/handlers/handle-add-query.ts
+++ b/src/handlers/handle-add-query.ts
@@ -10,6 +10,7 @@ import { createShortId, findRootError } from "#/utils";
 
 export const AddQueryReqBody = z.object({
   schemaName: z.string(),
+  description: z.string(),
   pipeline: z.array(z.unknown()),
 });
 export type AddQueryReqBody = z.infer<typeof AddQueryReqBody>;
@@ -45,6 +46,7 @@ export function handleAddQuery(app: Hono<AppEnv>, path: AddQueryPath): void {
           const id = createShortId(5);
           return {
             queryName: `${prefix}_query_${id}`,
+            queryDescription: reqBody.description,
             pipeline: JSON.stringify(reqBody.pipeline),
             startingSchema: reqBody.schemaName,
           };
@@ -54,6 +56,7 @@ export function handleAddQuery(app: Hono<AppEnv>, path: AddQueryPath): void {
         addOrgQueryRecord(
           orgId,
           body.queryName,
+          body.queryDescription,
           body.pipeline,
           body.startingSchema,
         ),

--- a/src/handlers/handle-list-queries.ts
+++ b/src/handlers/handle-list-queries.ts
@@ -22,7 +22,8 @@ export function handleListQueries(
         onSuccess: (queries) => {
           const data = Array.from(queries.entries()).map(([name, value]) => ({
             name,
-            pipeline: value.pipeline,
+            description: value.description,
+            pipeline: JSON.parse(value.pipeline),
             schema: value.schema,
           }));
           return c.json({ data });

--- a/src/models/orgs.ts
+++ b/src/models/orgs.ts
@@ -4,6 +4,7 @@ import mongoose from "mongoose";
 import type { CreateOrgReqBody } from "#/handlers/handle-create-org";
 
 export interface OrgQuery {
+  description: string;
   pipeline: string;
   schema: string;
 }
@@ -27,6 +28,7 @@ export const OrgDocumentSchema = new mongoose.Schema(
     queries: {
       type: Map,
       of: {
+        description: String,
         pipeline: String,
         schema: String,
       },

--- a/src/models/queries.ts
+++ b/src/models/queries.ts
@@ -35,6 +35,7 @@ export function removeOrgQueryRecord(
 export function addOrgQueryRecord(
   orgId: string,
   queryName: string,
+  description: string,
   pipeline: string,
   schema: string,
 ): E.Effect<OrgDocument, Error> {
@@ -45,6 +46,7 @@ export function addOrgQueryRecord(
         {
           $set: {
             [`queries.${queryName}`]: {
+              description,
               pipeline,
               schema,
             },

--- a/tests/fixture/client.ts
+++ b/tests/fixture/client.ts
@@ -214,7 +214,11 @@ export class TestClient {
     return response.ok;
   }
 
-  async addQuery(schemaName: string, pipeline: object[]): Promise<string> {
+  async addQuery(
+    schemaName: string,
+    description: string,
+    pipeline: object[],
+  ): Promise<string> {
     const path: AddQueryPath = `${apiV1}/orgs/queries`;
     const response = await this.app.request(path, {
       method: "POST",
@@ -222,7 +226,7 @@ export class TestClient {
         authorization: `Bearer ${this.jwt}`,
         "content-type": "application/json",
       },
-      body: JSON.stringify({ schemaName, pipeline }),
+      body: JSON.stringify({ schemaName, description, pipeline }),
     });
 
     return await response.text();

--- a/tests/orgs.test.ts
+++ b/tests/orgs.test.ts
@@ -38,6 +38,7 @@ describe("Orgs", () => {
       },
     },
     queryName: "",
+    queryDescription: "New Query",
     query: [
       {
         $match: {
@@ -192,7 +193,11 @@ describe("Orgs", () => {
   });
 
   it("can upload a query", async () => {
-    const id = await fixture.users.backend.addQuery(org.schemaName, org.query);
+    const id = await fixture.users.backend.addQuery(
+      org.schemaName,
+      org.queryDescription,
+      org.query,
+    );
     expect(id).toHaveLength(17);
     org.queryName = id;
   });


### PR DESCRIPTION
Fixes #13

Once deployed, existing queries should be updated to have a description.