### PR TITLE
feat: introduce `data/delete` endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -179,6 +179,22 @@ components:
           items:
             type: object
 
+    DeleteDataRequest:
+      type: object
+      required:
+        - schemaName
+        - keyName
+        - entriesToDelete
+      properties:
+        schemaName:
+          type: string
+        keyName:
+          type: string
+        entriesToDelete:
+          type: array
+          items:
+            type: string
+
     AddQueryRequest:
       type: object
       required:
@@ -399,6 +415,21 @@ paths:
       responses:
         '200':
           description: Data uploaded successfully
+
+  /api/v1/data/delete:
+    delete:
+      summary: Delete data
+      security:
+        - bearerAuth: [ ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteDataRequest'
+      responses:
+        '200':
+          description: Data deleted successfully
 
   /api/v1/orgs/queries:
     post:

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import { handleAddQuery } from "#/handlers/handle-add-query";
 import { handleAddSchema } from "#/handlers/handle-add-schema";
 import { handleCreateOrg } from "#/handlers/handle-create-org";
 import { handleCreateUser } from "#/handlers/handle-create-user";
+import { handleDeleteData } from "#/handlers/handle-delete-data";
 import { handleDeleteOrg } from "#/handlers/handle-delete-org";
 import { handleDeleteQuery } from "#/handlers/handle-delete-query";
 import { handleDeleteSchema } from "#/handlers/handle-delete-schema";
@@ -72,6 +73,7 @@ export function buildApp(
   handleDeleteUser(app, "/api/v1/users");
   handleRunQuery(app, "/api/v1/data/query");
   handleUploadData(app, "/api/v1/data/upload");
+  handleDeleteData(app, "/api/v1/data/delete");
   handleAddQuery(app, "/api/v1/orgs/queries");
   handleAddSchema(app, "/api/v1/orgs/schemas");
   handleCreateOrg(app, "/api/v1/orgs");

--- a/src/handlers/handle-delete-data.ts
+++ b/src/handlers/handle-delete-data.ts
@@ -1,0 +1,49 @@
+import { Effect as E } from "effect";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "#/app";
+import { deleteSchemaData } from "#/models/schemas";
+import { findRootError } from "#/utils";
+
+export const DeleteDataReqBody = z.object({
+  schemaName: z.string(),
+  keyName: z.string(),
+  entriesToDelete: z.array(z.union([z.string(), z.number()])),
+});
+export type DeleteDataReqBody = z.infer<typeof DeleteDataReqBody>;
+
+export type DeleteDataPath = "/api/v1/data/delete";
+
+export function handleDeleteData(
+  app: Hono<AppEnv>,
+  path: DeleteDataPath,
+): void {
+  app.delete(path, (c) => {
+    return E.Do.pipe(
+      E.let("orgId", () => c.get("jwtPayload").sub),
+      E.bind("reqBody", () =>
+        E.tryPromise(async () => {
+          const raw = await c.req.json<unknown>();
+          return DeleteDataReqBody.parse(raw);
+        }),
+      ),
+      E.flatMap(({ reqBody }) => {
+        const filter = {
+          [reqBody.keyName]: { $in: reqBody.entriesToDelete },
+        };
+        return deleteSchemaData(c.var.db.mongo, reqBody.schemaName, filter);
+      }),
+      E.match({
+        onFailure: (e) => {
+          const status = findRootError(e, "delete data", c.var.log);
+          return c.text("", status);
+        },
+        onSuccess: (name) => {
+          c.var.log.info(`Deleted data from collection ${name}`);
+          return c.text("", 200);
+        },
+      }),
+      E.runPromise,
+    );
+  });
+}

--- a/src/models/schemas.ts
+++ b/src/models/schemas.ts
@@ -141,3 +141,14 @@ export function insertSchemaData(
     E.map(() => collection),
   );
 }
+
+export function deleteSchemaData(
+  client: MongoClient,
+  collection: string,
+  filter: { [x: string]: { $in: (string | number)[] } },
+): E.Effect<string, Error> {
+  return pipe(
+    E.tryPromise(() => client.db().collection(collection).deleteMany(filter)),
+    E.map(() => collection),
+  );
+}

--- a/tests/fixture/client.ts
+++ b/tests/fixture/client.ts
@@ -11,6 +11,7 @@ import type {
   CreateUserPath,
   CreateUserReqBody,
 } from "#/handlers/handle-create-user";
+import type { DeleteDataPath } from "#/handlers/handle-delete-data";
 import type { DeleteOrgPath } from "#/handlers/handle-delete-org";
 import type { DeleteQueryPath } from "#/handlers/handle-delete-query";
 import type { DeleteSchemaPath } from "#/handlers/handle-delete-schema";
@@ -208,6 +209,28 @@ export class TestClient {
       body: JSON.stringify({
         schemaName,
         data,
+      }),
+    });
+
+    return response.ok;
+  }
+
+  async deleteData(
+    schemaName: string,
+    keyName: string,
+    entriesToDelete: (string | number)[],
+  ): Promise<boolean> {
+    const path: DeleteDataPath = `${apiV1}/data/delete`;
+    const response = await this.app.request(path, {
+      method: "DELETE",
+      headers: {
+        authorization: `Bearer ${this.jwt}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        schemaName,
+        keyName,
+        entriesToDelete,
       }),
     });
 

--- a/tests/orgs.test.ts
+++ b/tests/orgs.test.ts
@@ -186,6 +186,23 @@ describe("Orgs", () => {
     expect(records).toHaveLength(3);
   });
 
+  it("can delete data", async () => {
+    const name = org.schemaName;
+    const keyName = "country_code";
+    const entriesToDelete = ["CAN"];
+
+    const success = await fixture.users.backend.deleteData(
+      name,
+      keyName,
+      entriesToDelete,
+    );
+    expect(success).toBeTruthy;
+
+    const results = fixture.clients.db.db().collection(name).find({});
+    const records = await results.toArray();
+    expect(records).toHaveLength(2);
+  });
+
   it("can list queries", async () => {
     const { data } = await fixture.users.backend.listQueries();
     expect(data).toHaveLength(0);


### PR DESCRIPTION
Resolves #9

I'm not entirely happy with it being a `DELETE` method on an endpoint called `data/delete`, but neither `DELETE` on `data/upload`, nor `POST` on `data/delete` seemed better.