### PR TITLE
fix(infra): use 'nil-db' formatted role name

### DIFF
--- a/.github/workflows/cd-ecs.yaml
+++ b/.github/workflows/cd-ecs.yaml
@@ -34,7 +34,7 @@ jobs:
           framework: ecs_service
           deploy_env: sandbox
           deploy_roles: |
-            { "sandbox": "arn:aws:iam::767397865113:role/nildb-github" }
+            { "sandbox": "arn:aws:iam::767397865113:role/nil-db-github" }
           gha_app_id: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_ID }}
           gha_app_private_key: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
           tf_secrets_master_password: ${{ secrets.SECRETS_MASTER_PASSWORD }}

--- a/.github/workflows/cd-image.yaml
+++ b/.github/workflows/cd-image.yaml
@@ -28,7 +28,7 @@ jobs:
           framework: ecr_repo
           deploy_env: sandbox
           deploy_roles: |
-            { "sandbox": "arn:aws:iam::767397865113:role/nildb-github" }
+            { "sandbox": "arn:aws:iam::767397865113:role/nil-db-github" }
           gha_app_id: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_ID }}
           gha_app_private_key: ${{ secrets.NILLION_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
           tf_secrets_master_password: ${{ secrets.SECRETS_MASTER_PASSWORD }}
@@ -36,7 +36,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: "arn:aws:iam::767397865113:role/nildb-github"
+          role-to-assume: "arn:aws:iam::767397865113:role/nil-db-github"
           aws-region: "eu-west-1"
 
       - uses: aws-actions/amazon-ecr-login@v2


### PR DESCRIPTION
since we're wanting to keep the 'nil-db' format for deployment components,
instead of the repo name