### PR TITLE
chore: Publish Docker image to public ECR

### DIFF
--- a/.github/workflows/cd-image.yaml
+++ b/.github/workflows/cd-image.yaml
@@ -22,11 +22,13 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: "arn:aws:iam::470421895671:role/nil-db-github"
-          aws-region: "eu-west-1"
+          role-to-assume: "arn:aws:iam::054037142884:role/nil-db-github"
+          aws-region: "us-east-1"
 
       - uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
+        with:
+          registry-type: public
 
       - uses: docker/setup-buildx-action@v3
 
@@ -44,21 +46,24 @@ jobs:
       - name: Build and push images
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: k5d9x2g2
           ECR_REPOSITORY: nildb-api
           IMAGE_TAG_SHA: ${{ github.sha }}
         run: |
+          ECR_REGISTRY_URL="${ECR_REGISTRY}/${ECR_REGISTRY_ALIAS}/${ECR_REPOSITORY}"
+
           # Always tag with commit sha
-          TAGS="-t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG_SHA}"
-          
+          TAGS="-t ${ECR_REGISTRY_URL}:${IMAGE_TAG_SHA}"
+
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # On manual trigger, use version from package.json
             IMAGE_TAG_VERSION=$(cat package.json | jq -r .version)
-            TAGS="$TAGS -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG_VERSION}"
+            TAGS="$TAGS -t ${ECR_REGISTRY_URL}:${IMAGE_TAG_VERSION}"
           else
             # If triggered by push to main, use latest tag
-            TAGS="$TAGS -t ${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+            TAGS="$TAGS -t ${ECR_REGISTRY_URL}:latest"
           fi
-          
+
           docker build \
             --push \
             -f Dockerfile \


### PR DESCRIPTION
This commit modifies the `cd-image.yaml` workflow to publish NilDB Docker images to the public ECR repository.

A few notes:

* Public ECRs are only supported in us-east-1.

* We are publishing to the `platform` account (054037142884)

* There is a randomly generated registry alias and an opaque approval process for a custom one. Currently, "nillion" is in the process of getting approved, and we have to use "k5d9x2g2" for now.

* We are still awaiting rollout of a fix to GitHub OIDC permissions for the NilDB role in https://github.com/NillionNetwork/devops/pull/1393. Though this has been tested with manual adjustments to the existing IAM role policy.