### PR TITLE
chore: update admin-guide, admin account creation step

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -123,7 +123,12 @@ Use the root jwt to create the admin account:
  curl ${NODE_URL}/api/v1/admin/accounts \
    --header "Authorization: Bearer ${ROOT_JWT}" \
    --header "Content-type: application/json" \
-   -d '{ "did": "${ADMIN_DID}", "publicKey": "${ADMIN_PK}" }'
+   -d '{
+       "type": "admin",
+       "name": "${ADMIN_NAME}",
+       "did": "${ADMIN_DID}", 
+       "publicKey": "${ADMIN_PK}" 
+   }'
  ```
 
 Create a JWT for the admin account:


### PR DESCRIPTION
Updated the admin account creation step of the admin guide. Omitting `type` and `name` causes subsequent requests to `GET /admin/accounts` to return:
```json
{"ts":"2025-03-13T10:21:47.204Z","errors":["key=name, reason=Required","key=type, reason=Required"]}
```