### PR TITLE
Fix formatting in pipeline description in OpenAPI schema

### DIFF
--- a/src/queries/queries.openapi.yaml
+++ b/src/queries/queries.openapi.yaml
@@ -29,7 +29,7 @@ components:
                   - $ref: '#/components/schemas/QueryVariable'
                   - $ref: '#/components/schemas/QueryArrayVariable'
             pipeline:
-              description: An query's execution pipline defined as an array of objects
+              description: An query's execution pipeline defined as an array of objects
               type: array
               items:
                 type: object


### PR DESCRIPTION
This PR removes code formatting from the word "pipeline" in the description field of the pipeline property in the queries OpenAPI schema. This change ensures consistent formatting throughout the documentation.