### PR TITLE
feat!: support optional query variables

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -99,6 +99,8 @@ export class DataCollectionNotFoundError extends Data.TaggedError(
   }
 }
 
+export type QueryValidationError = VariableInjectionError | DataValidationError;
+
 export class DataValidationError extends Data.TaggedError(
   "DataValidationError",
 )<{

--- a/src/queries/queries.openapi.yaml
+++ b/src/queries/queries.openapi.yaml
@@ -39,12 +39,17 @@ components:
       required:
         - type
         - description
+        - path
       properties:
         type:
           type: string
           enum: [ 'string', 'number', 'boolean', 'date' ]
         description:
           type: string
+        path:
+          type: string
+        optional:
+          type: boolean
 
     QueryArrayVariable:
       type: object
@@ -52,6 +57,7 @@ components:
         - type
         - description
         - items
+        - path
       properties:
         type:
           type: string
@@ -66,6 +72,10 @@ components:
             type:
               type: string
               enum: [ 'string', 'number', 'boolean', 'date' ]
+        path:
+          type: string
+        optional:
+          type: boolean
 
 paths:
   /api/v1/queries:

--- a/src/queries/queries.openapi.yaml
+++ b/src/queries/queries.openapi.yaml
@@ -38,7 +38,6 @@ components:
       type: object
       required:
         - type
-        - description
         - path
       properties:
         type:
@@ -55,7 +54,6 @@ components:
       type: object
       required:
         - type
-        - description
         - items
         - path
       properties:

--- a/src/queries/queries.types.ts
+++ b/src/queries/queries.types.ts
@@ -19,12 +19,12 @@ export const QueryVariableValidatorSchema = z.union([
   z.object({
     type: VariablePrimitiveSchema,
     path: VariablePathSchema,
-    description: z.string(),
+    description: z.string().optional(),
   }),
   z.object({
     type: z.enum(["array"]),
     path: VariablePathSchema,
-    description: z.string(),
+    description: z.string().optional(),
     items: z.object({
       type: VariablePrimitiveSchema,
     }),
@@ -57,14 +57,14 @@ export type ExecuteQueryRequest = z.infer<typeof ExecuteQueryRequestSchema>;
 export type QueryVariable = {
   type: "string" | "number" | "boolean" | "date";
   path: string;
-  description: string;
+  description?: string;
   optional?: boolean;
 };
 
 export type QueryArrayVariable = {
   type: "array";
   path: string;
-  description: string;
+  description?: string;
   items: {
     type: "string" | "number" | "boolean" | "date";
   };

--- a/src/queries/queries.types.ts
+++ b/src/queries/queries.types.ts
@@ -58,6 +58,7 @@ export type QueryVariable = {
   type: "string" | "number" | "boolean" | "date";
   path: string;
   description: string;
+  optional?: boolean;
 };
 
 export type QueryArrayVariable = {
@@ -67,6 +68,7 @@ export type QueryArrayVariable = {
   items: {
     type: "string" | "number" | "boolean" | "date";
   };
+  optional?: boolean;
 };
 
 export type QueryDocument = DocumentBase & {

--- a/tests/inject-variable.pipeline.test.ts
+++ b/tests/inject-variable.pipeline.test.ts
@@ -78,8 +78,8 @@ describe("pipeline variable injection", () => {
       {
         $match: {
           wallet: "##address",
-          amount: "##value",
-          active: "##isActive",
+          amount: 1,
+          active: false,
         },
       },
     ];
@@ -102,6 +102,58 @@ describe("pipeline variable injection", () => {
           wallet: "abc123",
           amount: 1000,
           active: false,
+        },
+      },
+    ];
+
+    expect(actual.pipeline).toEqual(expected);
+  });
+
+  it("replaces optional variables", async ({ expect }) => {
+    const queryVariables = {
+      address: {
+        description: "",
+        type: "string",
+        path: "$.pipeline[0].$match.wallet",
+        optional: true,
+      },
+      value: {
+        description: "",
+        type: "number",
+        path: "$.pipeline[0].$match.amount",
+        optional: true,
+      },
+      isActive: {
+        description: "",
+        type: "boolean",
+        path: "$.pipeline[0].$match.active",
+        optional: true,
+      },
+    };
+    const pipeline = [
+      {
+        $match: {
+          wallet: "##address",
+          amount: 1,
+          active: true,
+        },
+      },
+    ];
+
+    const requestVariables = {};
+
+    const actual = executePartialQuery(
+      queryVariables,
+      pipeline,
+      requestVariables,
+    );
+
+    const expected = [
+      {
+        $match: {
+          wallet: "##address",
+          amount: 1,
+          active: true,
         },
       },
     ];
@@ -218,7 +270,7 @@ describe("pipeline variable injection", () => {
       {
         $group: {
           _id: { $concat: ["$joined.", "##groupField"] },
-          total: { $sum: "##valueField" },
+          total: { $sum: 0 },
         },
       },
     ];

--- a/tests/inject-variable.pipeline.test.ts
+++ b/tests/inject-variable.pipeline.test.ts
@@ -6,10 +6,13 @@ import {
   injectVariablesIntoAggregation,
   validateVariables,
 } from "#/queries/queries.services";
-import type { QueryVariable } from "#/queries/queries.types";
+import type {
+  QueryArrayVariable,
+  QueryVariable,
+} from "#/queries/queries.types";
 
 function executePartialQuery(
-  queryVariables: Record<string, QueryRuntimeVariables>,
+  queryVariables: Record<string, QueryVariable | QueryArrayVariable>,
   pipeline: Record<string, unknown>[],
   requestVariables: Record<string, unknown>,
 ) {
@@ -26,20 +29,19 @@ function executePartialQuery(
 
 describe("pipeline variable injection", () => {
   it("replaces simple variables", async ({ expect }) => {
-    const queryVariables = {
+    const queryVariables: Record<string, QueryVariable> = {
       address: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.wallet",
       },
     };
     const pipeline = [
       {
-        $match: { wallet: "##address" },
+        $match: { wallet: "" },
       },
     ];
 
-    const requestVariables = { address: "abc123" };
+    const requestVariables: QueryRuntimeVariables = { address: "abc123" };
 
     const actual = executePartialQuery(
       queryVariables,
@@ -57,19 +59,16 @@ describe("pipeline variable injection", () => {
   });
 
   it("replaces multiple variable types", async ({ expect }) => {
-    const queryVariables = {
+    const queryVariables: Record<string, QueryVariable> = {
       address: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.wallet",
       },
       value: {
-        description: "",
         type: "number",
         path: "$.pipeline[0].$match.amount",
       },
       isActive: {
-        description: "",
         type: "boolean",
         path: "$.pipeline[0].$match.active",
       },
@@ -77,8 +76,8 @@ describe("pipeline variable injection", () => {
     const pipeline = [
       {
         $match: {
-          wallet: "##address",
-          amount: 1,
+          wallet: "",
+          amount: 0,
           active: false,
         },
       },
@@ -87,7 +86,7 @@ describe("pipeline variable injection", () => {
     const requestVariables = {
       address: "abc123",
       value: 1000,
-      isActive: false,
+      isActive: true,
     };
 
     const actual = executePartialQuery(
@@ -101,7 +100,7 @@ describe("pipeline variable injection", () => {
         $match: {
           wallet: "abc123",
           amount: 1000,
-          active: false,
+          active: true,
         },
       },
     ];
@@ -110,21 +109,18 @@ describe("pipeline variable injection", () => {
   });
 
   it("replaces optional variables", async ({ expect }) => {
-    const queryVariables = {
+    const queryVariables: Record<string, QueryVariable> = {
       address: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.wallet",
         optional: true,
       },
       value: {
-        description: "",
         type: "number",
         path: "$.pipeline[0].$match.amount",
         optional: true,
       },
       isActive: {
-        description: "",
         type: "boolean",
         path: "$.pipeline[0].$match.active",
         optional: true,
@@ -133,9 +129,9 @@ describe("pipeline variable injection", () => {
     const pipeline = [
       {
         $match: {
-          wallet: "##address",
-          amount: 1,
-          active: true,
+          wallet: "",
+          amount: 0,
+          active: false,
         },
       },
     ];
@@ -151,9 +147,9 @@ describe("pipeline variable injection", () => {
     const expected = [
       {
         $match: {
-          wallet: "##address",
-          amount: 1,
-          active: true,
+          wallet: "",
+          amount: 0,
+          active: false,
         },
       },
     ];
@@ -162,12 +158,11 @@ describe("pipeline variable injection", () => {
   });
 
   it("throws error for unexpected variables", async ({ expect }) => {
-    const queryVariables = {
+    const queryVariables: Record<string, QueryVariable> = {
       address: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.wallet",
-      } as QueryVariable,
+      },
     };
 
     const variables = {
@@ -191,12 +186,11 @@ describe("pipeline variable injection", () => {
   });
 
   it("throws error for missing variables", async ({ expect }) => {
-    const queryVariables = {
+    const queryVariables: Record<string, QueryVariable> = {
       address: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.wallet",
-      } as QueryVariable,
+      },
     };
 
     const variables = {};
@@ -217,34 +211,28 @@ describe("pipeline variable injection", () => {
   });
 
   it("handles complex pipeline with multiple stages", async ({ expect }) => {
-    const queryVariables = {
+    const queryVariables: Record<string, QueryVariable> = {
       status: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.status",
       },
       startDate: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match._created.$gt",
       },
       collection: {
-        description: "",
         type: "string",
         path: "$.pipeline[1].$lookup.from",
       },
       localField: {
-        description: "",
         type: "string",
         path: "$.pipeline[1].$lookup.localField",
       },
       groupField: {
-        description: "",
         type: "string",
         path: "$.pipeline[3].$group._id.$concat[1]",
       },
       valueField: {
-        description: "",
         type: "number",
         path: "$.pipeline[3].$group.total.$sum",
       },
@@ -252,14 +240,14 @@ describe("pipeline variable injection", () => {
     const pipeline = [
       {
         $match: {
-          status: "##status",
-          _created: { $gt: "##startDate" },
+          status: "",
+          _created: { $gt: "" },
         },
       },
       {
         $lookup: {
-          from: "##collection",
-          localField: "##localField",
+          from: "",
+          localField: "",
           foreignField: "id",
           as: "joined",
         },
@@ -269,7 +257,7 @@ describe("pipeline variable injection", () => {
       },
       {
         $group: {
-          _id: { $concat: ["$joined.", "##groupField"] },
+          _id: { $concat: ["$joined.", ""] },
           total: { $sum: 0 },
         },
       },
@@ -320,29 +308,24 @@ describe("pipeline variable injection", () => {
   });
 
   it("handles deeply nested structures", async ({ expect }) => {
-    const queryVariables = {
+    const queryVariables: Record<string, QueryVariable> = {
       type1: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.$or[0].type",
       },
       category1: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.$or[1].category.$in[0]",
       },
       category2: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.$or[1].category.$in[1]",
       },
       status: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.$or[2].$and[0].status",
       },
       deepValue: {
-        description: "",
         type: "string",
         path: "$.pipeline[0].$match.$or[2].$and[1].nested.deep.value",
       },
@@ -352,15 +335,15 @@ describe("pipeline variable injection", () => {
       {
         $match: {
           $or: [
-            { type: "##type1" },
-            { category: { $in: ["##category1", "##category2"] } },
+            { type: "" },
+            { category: { $in: ["", ""] } },
             {
               $and: [
-                { status: "##status" },
+                { status: "" },
                 {
                   nested: {
                     deep: {
-                      value: "##deepValue",
+                      value: "",
                     },
                   },
                 },

--- a/tests/queries-validation.test.ts
+++ b/tests/queries-validation.test.ts
@@ -1,0 +1,215 @@
+import { Did } from "@nillion/nuc";
+import { Effect as E, Either, pipe } from "effect";
+import { UUID } from "mongodb";
+import { describe, it } from "vitest";
+import { validateQuery } from "#/queries/queries.services";
+import type {
+  QueryArrayVariable,
+  QueryDocument,
+  QueryVariable,
+} from "#/queries/queries.types";
+
+describe("query definition", () => {
+  it("valid query", async ({ expect }) => {
+    const variables: Record<string, QueryVariable | QueryArrayVariable> = {
+      minAmount: {
+        type: "number",
+        description: "Minimum amount filter",
+        path: "$.pipeline[0].$match.amount.$gte",
+      },
+      status: {
+        type: "string",
+        description: "Status to filter by",
+        path: "$.pipeline[0].$match.status",
+      },
+      startDate: {
+        type: "date",
+        description: "Start date filter",
+        path: "$.pipeline[0].$match.timestamp.$gte",
+      },
+    };
+
+    const pipeline = [
+      {
+        $match: {
+          amount: {
+            $gte: 0,
+          },
+          status: "",
+          timestamp: {
+            $gte: "1970-01-01T00:00:00.000Z",
+          },
+        },
+      },
+      {
+        $group: {
+          _id: "$status",
+          totalAmount: {
+            $sum: "$amount",
+          },
+          count: {
+            $sum: 1,
+          },
+        },
+      },
+      {
+        $sort: {
+          totalAmount: -1,
+        },
+      },
+    ];
+
+    const result = pipe(
+      validateQuery(buildQuery(variables, pipeline)),
+      E.either,
+      E.runSync,
+    );
+    expect(Either.isRight(result)).toBe(true);
+  });
+
+  it("valid array query", async ({ expect }) => {
+    const variables: Record<string, QueryVariable | QueryArrayVariable> = {
+      values: {
+        type: "array",
+        description: "The values to find",
+        items: {
+          type: "number",
+        },
+        path: "$.pipeline[0].$match.values",
+      },
+    };
+
+    const pipeline = [
+      {
+        $match: {
+          values: [1, 2, 3, 4, 5],
+        },
+      },
+    ];
+
+    const result = pipe(
+      validateQuery(buildQuery(variables, pipeline)),
+      E.either,
+      E.runSync,
+    );
+    expect(Either.isRight(result)).toBe(true);
+  });
+
+  it("unexpected type", async ({ expect }) => {
+    const variables: Record<string, QueryVariable | QueryArrayVariable> = {
+      minAmount: {
+        type: "number",
+        description: "Minimum amount filter",
+        path: "$.pipeline[0].$match.amount.$gte",
+      },
+    };
+
+    const pipeline = [
+      {
+        $match: {
+          amount: {
+            $gte: "",
+          },
+        },
+      },
+    ];
+
+    const result = pipe(
+      validateQuery(buildQuery(variables, pipeline)),
+      E.either,
+      E.runSync,
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      const error = result.left.humanize();
+      expect(error[0]).toBe("DataValidationError");
+      expect(error[1]).toBe('Expected number, received string at "minAmount"');
+    }
+  });
+
+  it("unexpected inner type", async ({ expect }) => {
+    const variables: Record<string, QueryVariable | QueryArrayVariable> = {
+      values: {
+        type: "array",
+        description: "The values to find",
+        items: {
+          type: "number",
+        },
+        path: "$.pipeline[0].$match.values",
+      },
+    };
+
+    const pipeline = [
+      {
+        $match: {
+          values: [1, 2, "3", 4, 5],
+        },
+      },
+    ];
+
+    const result = pipe(
+      validateQuery(buildQuery(variables, pipeline)),
+      E.either,
+      E.runSync,
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      const error = result.left.humanize();
+      expect(error[0]).toBe("DataValidationError");
+      expect(error[1]).toBe('Expected number, received string at "values"');
+    }
+  });
+
+  it("variable not found", async ({ expect }) => {
+    const variables: Record<string, QueryVariable | QueryArrayVariable> = {
+      minAmount: {
+        type: "number",
+        description: "Minimum amount filter",
+        path: "$.pipeline[0].$match.amount.$gte",
+      },
+      status: {
+        type: "string",
+        description: "Status to filter by",
+        path: "$.pipeline[0].$match.status",
+      },
+    };
+
+    const pipeline = [
+      {
+        $match: {
+          amount: {
+            $gte: 0,
+          },
+        },
+      },
+    ];
+
+    const result = pipe(
+      validateQuery(buildQuery(variables, pipeline)),
+      E.either,
+      E.runSync,
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      const error = result.left.humanize();
+      expect(error[0]).toBe("VariableInjectionError");
+      expect(error[1]).contains("Variable path not found");
+    }
+  });
+});
+
+function buildQuery(
+  variables: Record<string, QueryVariable | QueryArrayVariable>,
+  pipeline: Record<string, unknown>[],
+): QueryDocument {
+  return {
+    _id: new UUID(),
+    _created: new Date(),
+    _updated: new Date(),
+    owner: new Did(Uint8Array.from(Array(33).fill(0xaa))).toString(),
+    name: "variables.wallet.query.json",
+    schema: new UUID(),
+    variables,
+    pipeline,
+  };
+}


### PR DESCRIPTION
closes #172 .

As we discussed [here](https://github.com/NillionNetwork/nildb/pull/166#issuecomment-2862611689). This forces the placeholder value to have the correct type from now. In addition, 
- We validate the query when is added. I is rejected if it's malformed.
- Adds an attribute `optional: boolean|undefined` to the variable (if it's undefined, it's false)
- Uses the placeholder value as the default value.