### PR TITLE
feat!: support for coercions in query variables

### DIFF
--- a/src/common/mongo.ts
+++ b/src/common/mongo.ts
@@ -156,26 +156,30 @@ function applyCoercionToField(
     if (typeof coercibleValues[field] === "object") {
       const value = coercibleValues[field] as Record<string, unknown>;
       for (const op in value) {
-        if (op.startsWith("$") && Array.isArray(value[op])) {
+        if (Array.isArray(value[op])) {
           value[op] = Array.from(value[op]).map((innerValue) =>
-            toPrimitiveValue(innerValue, type),
+            coerceValue(innerValue, type),
           );
         }
       }
     } else {
-      coercibleValues[field] = toPrimitiveValue(coercibleValues[field], type);
+      coercibleValues[field] = coerceValue(coercibleValues[field], type);
     }
   }
 }
 
-function toPrimitiveValue(value: unknown, type: string): unknown {
-  if (typeof value === "string") {
-    switch (type.toLowerCase()) {
-      case "uuid":
-        return new UUID(value);
-      case "date":
-        return new Date(value);
-    }
+function coerceValue(value: unknown, type: string): unknown {
+  switch (type.toLowerCase()) {
+    case "string":
+      return `${value}`;
+    case "number":
+      return Number(value);
+    case "boolean":
+      return Boolean(value);
+    case "uuid":
+      return new UUID(`${value}`);
+    case "date":
+      return new Date(`${value}`);
   }
   return value;
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,7 +15,13 @@ export function createUuidDto(): UuidDto {
   return new UUID().toString() as UuidDto;
 }
 
-export const CoercibleTypesSchema = z.enum(["date", "uuid"] as const);
+export const CoercibleTypesSchema = z.enum([
+  "string",
+  "number",
+  "boolean",
+  "date",
+  "uuid",
+] as const);
 export type CoercibleTypes = z.infer<typeof CoercibleTypesSchema>;
 
 export const CoercibleValuesSchema = z.record(z.string(), z.unknown());

--- a/src/data/data.services.ts
+++ b/src/data/data.services.ts
@@ -49,7 +49,10 @@ export function createRecords(
 export function updateRecords(
   ctx: AppBindings,
   request: UpdateDataRequest,
-): E.Effect<UpdateResult, DataCollectionNotFoundError | DatabaseError> {
+): E.Effect<
+  UpdateResult,
+  DataCollectionNotFoundError | DatabaseError | DataValidationError
+> {
   return pipe(
     DataRepository.updateMany(
       ctx,
@@ -63,7 +66,10 @@ export function updateRecords(
 export function readRecords(
   ctx: AppBindings,
   request: ReadDataRequest,
-): E.Effect<DataDocument[], DataCollectionNotFoundError | DatabaseError> {
+): E.Effect<
+  DataDocument[],
+  DataCollectionNotFoundError | DatabaseError | DataValidationError
+> {
   return pipe(
     E.succeed(request),
     E.map(({ schema, filter }) => {
@@ -81,7 +87,11 @@ export function readRecords(
 export function deleteRecords(
   ctx: AppBindings,
   request: DeleteDataRequest,
-): E.Effect<DeleteResult, DataCollectionNotFoundError | DatabaseError, never> {
+): E.Effect<
+  DeleteResult,
+  DataCollectionNotFoundError | DatabaseError | DataValidationError,
+  never
+> {
   return pipe(DataRepository.deleteMany(ctx, request.schema, request.filter));
 }
 

--- a/src/queries/queries.openapi.yaml
+++ b/src/queries/queries.openapi.yaml
@@ -37,7 +37,6 @@ components:
     QueryVariable:
       type: object
       required:
-        - type
         - path
       properties:
         type:
@@ -45,31 +44,16 @@ components:
           enum: [ 'string', 'number', 'boolean', 'date' ]
         description:
           type: string
-        path:
-          type: string
         optional:
           type: boolean
 
     QueryArrayVariable:
       type: object
       required:
-        - type
-        - items
         - path
       properties:
-        type:
-          type: string
-          enum: [ 'array' ]
         description:
           type: string
-        items:
-          type: object
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum: [ 'string', 'number', 'boolean', 'date' ]
         path:
           type: string
         optional:

--- a/src/queries/queries.services.ts
+++ b/src/queries/queries.services.ts
@@ -11,6 +11,7 @@ import {
   type QueryValidationError,
   VariableInjectionError,
 } from "#/common/errors";
+import { applyCoercions } from "#/common/mongo";
 import type { Did } from "#/common/types";
 import { validateData } from "#/common/validator";
 import * as DataRepository from "#/data/data.repository";
@@ -21,7 +22,6 @@ import * as QueriesRepository from "./queries.repository";
 import type {
   AddQueryRequest,
   ExecuteQueryRequest,
-  QueryArrayVariable,
   QueryDocument,
   QueryVariable,
 } from "./queries.types";
@@ -72,7 +72,11 @@ export function executeQuery(
       validateVariables(query.variables, request.variables),
     ),
     E.bind("pipeline", ({ query, variables }) =>
-      injectVariablesIntoAggregation(query.pipeline, variables),
+      injectVariablesIntoAggregation(
+        query.variables,
+        query.pipeline,
+        variables,
+      ),
     ),
     E.flatMap(({ query, pipeline }) => {
       return pipe(DataRepository.runAggregation(ctx, query, pipeline));
@@ -115,23 +119,18 @@ export function validateQuery(
 
   const validateVariableDefinition: (
     key: string,
-    variable: QueryVariable | QueryArrayVariable,
-  ) => E.Effect<QueryVariable | QueryArrayVariable, QueryValidationError> = (
-    key,
-    variable,
-  ) => {
+    variable: QueryVariable,
+  ) => E.Effect<QueryVariable, QueryValidationError> = (key, variable) => {
     return pipe(
       pathSegments(variable.path),
       E.andThen((segments) => getAggregationField(pipeline, segments)),
       E.andThen((value) => {
-        if (variable.type === "array") {
-          const itemType = (variable as QueryArrayVariable).items.type;
-          return E.forEach(value as unknown[], (item) =>
-            parsePrimitiveVariable(key, item, itemType),
-          ).pipe(E.andThen(() => E.succeed(variable)));
+        if (Array.isArray(value)) {
+          return validateArray(key, value as unknown[]).pipe(
+            E.andThen(() => E.succeed(variable)),
+          );
         }
-        return pipe(
-          parsePrimitiveVariable(key, value, variable.type),
+        return primitiveType(key, value).pipe(
           E.andThen(() => E.succeed(variable)),
         );
       }),
@@ -154,8 +153,8 @@ export function validateVariables(
   template: QueryDocument["variables"],
   provided: ExecuteQueryRequest["variables"],
 ): E.Effect<QueryRuntimeVariables, DataValidationError> {
-  const permittedTypes = ["array", "string", "number", "boolean", "date"];
-  const providedKeys = Object.keys(provided);
+  const { $coerce, ...values } = provided;
+  const providedKeys = Object.keys(values);
   const permittedKeys = Object.keys(template);
 
   const missingVariables = permittedKeys.filter(
@@ -181,94 +180,60 @@ export function validateVariables(
     return E.fail(error);
   }
 
-  return pipe(
-    providedKeys,
-    E.forEach((key) => {
-      const variableTemplate = template[key];
+  return E.forEach(Object.entries(values), ([key, value]) => {
+    if (Array.isArray(value)) {
+      return validateArray(key, value as unknown[]).pipe(E.map(() => value));
+    }
+    return primitiveType(key, value).pipe(E.map(() => value));
+  }).pipe(E.map(() => applyCoercions(provided)));
+}
 
-      const type = variableTemplate.type.toLowerCase();
-      if (!permittedTypes.includes(type)) {
-        const issues = ["Unsupported type", `type=${type}`];
-        const error = new DataValidationError({
-          issues,
-          cause: {
-            template,
-            provided,
-          },
-        });
-        return E.fail(error);
-      }
-
-      if (type === "array") {
-        const itemType = (template[key] as QueryArrayVariable).items.type;
-        return pipe(
-          provided[key] as unknown[],
-          E.forEach((item) => parsePrimitiveVariable(key, item, itemType)),
-          E.map(
-            (values) => [variableTemplate.path, values] as [string, unknown],
-          ),
-        );
-      }
-
-      return pipe(
-        parsePrimitiveVariable(key, provided[key], type),
-        E.map((value) => [variableTemplate.path, value] as [string, unknown]),
-      );
-    }),
-    E.map((entries) => Object.fromEntries(entries) as QueryRuntimeVariables),
+function validateArray<T = unknown>(
+  key: string,
+  value: unknown[],
+): E.Effect<T, DataValidationError> {
+  const allTypesEquals = (types: PrimitiveType[]) => {
+    if (types.length === 0 || types.every((t) => t === types[0])) {
+      return E.succeed(types);
+    }
+    const issues = ["Unsupported mixed-type array"];
+    const error = new DataValidationError({
+      issues,
+      cause: { key, value },
+    });
+    return E.fail(error);
+  };
+  return E.forEach(value as unknown[], (item) => primitiveType(key, item)).pipe(
+    E.andThen((types) => allTypesEquals(types)),
+    E.andThen(() => E.succeed(value as T)),
   );
 }
 
-function parsePrimitiveVariable(
+type PrimitiveType = "string" | "number" | "boolean";
+function primitiveType(
   key: string,
   value: unknown,
-  type: QueryPrimitive,
-): E.Effect<QueryPrimitive, DataValidationError> {
+): E.Effect<PrimitiveType, DataValidationError> {
   let result:
     | { data: QueryPrimitive; success: true }
     | { success: false; error: z.ZodError };
 
-  switch (type) {
-    case "string": {
-      result = z.string().safeParse(value, { path: [key] });
-      break;
-    }
-    case "number": {
-      result = z.number().safeParse(value, { path: [key] });
-      break;
-    }
-    case "boolean": {
-      result = z.boolean().safeParse(value, { path: [key] });
-      break;
-    }
-    case "date": {
-      result = z
-        .preprocess((arg) => {
-          if (arg === null || arg === undefined) return undefined;
-          if (typeof arg !== "string") return undefined;
-          return new Date(arg);
-        }, z.date())
-        .safeParse(value, { path: [key] });
-
-      break;
-    }
-    default: {
-      const issues = ["Unsupported type"];
-      const error = new DataValidationError({
-        issues,
-        cause: { key, value, type },
-      });
-      return E.fail(error);
-    }
-  }
-
+  result = z.string().safeParse(value, { path: [key] });
   if (result.success) {
-    return E.succeed(result.data);
+    return E.succeed("string");
   }
-
+  result = z.number().safeParse(value, { path: [key] });
+  if (result.success) {
+    return E.succeed("number");
+  }
+  result = z.boolean().safeParse(value, { path: [key] });
+  if (result.success) {
+    return E.succeed("boolean");
+  }
+  const issues = ["Unsupported value type"];
   const error = new DataValidationError({
-    issues: [result.error],
-    cause: null,
+    issues,
+    cause: { key, value },
   });
   return E.fail(error);
 }
@@ -304,6 +269,7 @@ function getAggregationField(
 }
 
 export function injectVariablesIntoAggregation(
+  queryVariables: Record<string, QueryVariable>,
   aggregation: Record<string, unknown>[],
   variables: QueryRuntimeVariables,
 ): E.Effect<Document[], VariableInjectionError> {
@@ -349,7 +315,7 @@ export function injectVariablesIntoAggregation(
   };
 
   return E.forEach(Object.entries(variables), ([key, value]) =>
-    injectVariables(key, value),
+    injectVariables(queryVariables[key].path, value),
   ).pipe(E.map((_) => aggregation as JsonValue as Document[]));
 }
 

--- a/src/queries/queries.types.ts
+++ b/src/queries/queries.types.ts
@@ -14,22 +14,10 @@ const VariablePathSchema = z
 /**
  * Controller types
  */
-const VariablePrimitiveSchema = z.enum(["string", "number", "boolean", "date"]);
-export const QueryVariableValidatorSchema = z.union([
-  z.object({
-    type: VariablePrimitiveSchema,
-    path: VariablePathSchema,
-    description: z.string().optional(),
-  }),
-  z.object({
-    type: z.enum(["array"]),
-    path: VariablePathSchema,
-    description: z.string().optional(),
-    items: z.object({
-      type: VariablePrimitiveSchema,
-    }),
-  }),
-]);
+export const QueryVariableValidatorSchema = z.object({
+  path: VariablePathSchema,
+  description: z.string().optional(),
+});
 
 export const AddQueryRequestSchema = z.object({
   _id: Uuid,
@@ -55,19 +43,8 @@ export type ExecuteQueryRequest = z.infer<typeof ExecuteQueryRequestSchema>;
  * Repository types
  */
 export type QueryVariable = {
-  type: "string" | "number" | "boolean" | "date";
   path: string;
   description?: string;
-  optional?: boolean;
-};
-
-export type QueryArrayVariable = {
-  type: "array";
-  path: string;
-  description?: string;
-  items: {
-    type: "string" | "number" | "boolean" | "date";
-  };
   optional?: boolean;
 };
 
@@ -76,6 +53,6 @@ export type QueryDocument = DocumentBase & {
   name: string;
   // the query's starting collection
   schema: UUID;
-  variables: Record<string, QueryVariable | QueryArrayVariable>;
+  variables: Record<string, QueryVariable>;
   pipeline: Record<string, unknown>[];
 };

--- a/src/schemas/schemas.services.ts
+++ b/src/schemas/schemas.services.ts
@@ -5,6 +5,7 @@ import type { CreateSchemaIndexRequest } from "#/admin/admin.types";
 import type {
   DatabaseError,
   DataCollectionNotFoundError,
+  DataValidationError,
   DocumentNotFoundError,
   IndexNotFoundError,
   InvalidIndexOptionsError,
@@ -24,7 +25,10 @@ export function getOrganizationSchemas(
   organization: OrganizationAccountDocument,
 ): E.Effect<
   SchemaDocument[],
-  DocumentNotFoundError | PrimaryCollectionNotFoundError | DatabaseError
+  | DocumentNotFoundError
+  | PrimaryCollectionNotFoundError
+  | DatabaseError
+  | DataValidationError
 > {
   return SchemasRepository.findMany(ctx, { owner: organization._id });
 }
@@ -68,6 +72,7 @@ export function deleteSchema(
   | DataCollectionNotFoundError
   | PrimaryCollectionNotFoundError
   | DatabaseError
+  | DataValidationError
 > {
   return pipe(
     SchemasRepository.deleteOne(ctx, { _id: schemaId }),

--- a/tests/coercions.test.ts
+++ b/tests/coercions.test.ts
@@ -11,6 +11,7 @@ import {
 import type { SchemaFixture } from "./fixture/fixture";
 import { createTestFixtureExtension } from "./fixture/it";
 
+// TODO add more tests for the new coercions types: int, boolean, string
 describe("data operations", () => {
   const schema = schemaJson as unknown as SchemaFixture;
   const { it, beforeAll, afterAll } = createTestFixtureExtension({
@@ -78,6 +79,33 @@ describe("data operations", () => {
     const coercedData = applyCoercions(data) as CoercibleMap;
     const coercedDates = coercedData._created as Record<string, unknown>;
     expect(coercedDates.$in).toStrictEqual(expected);
+  });
+
+  it("coerces mixed values", async ({ expect }) => {
+    const identifiers = [
+      "3f5c92dd-214a-49b5-a129-e56c29fe5d3a",
+      "3f5c92dd-214a-49b5-a129-e56c29fe5d3a",
+    ];
+    const expectedUuids = identifiers.map((id) => new UUID(id));
+    const dates = ["2025-02-24T17:09:00.267Z", "2025-02-24T17:09:00.267Z"];
+    const expectedDates = dates.map((date) => new Date(date));
+    const data: CoercibleMap = {
+      identifiers: {
+        $in: identifiers,
+      },
+      dates: {
+        $in: dates,
+      },
+      $coerce: {
+        identifiers: "uuid",
+        dates: "date",
+      },
+    };
+    const coercedData = applyCoercions(data) as CoercibleMap;
+    const coercedUuids = coercedData.identifiers as Record<string, unknown>;
+    expect(coercedUuids.$in).toStrictEqual(expectedUuids);
+    const coercedDates = coercedData.dates as Record<string, unknown>;
+    expect(coercedDates.$in).toStrictEqual(expectedDates);
   });
 
   it("do not coerce value", async ({ expect }) => {

--- a/tests/data/simple.query.json
+++ b/tests/data/simple.query.json
@@ -4,7 +4,6 @@
   "schema": "",
   "variables": {
     "name": {
-      "type": "string",
       "description": "The name value",
       "path": "$.pipeline[0].$match.name"
     }

--- a/tests/data/variables.array.query.json
+++ b/tests/data/variables.array.query.json
@@ -4,11 +4,7 @@
   "schema": "",
   "variables": {
     "values": {
-      "type": "array",
       "description": "The values to find",
-      "items": {
-        "type": "number"
-      },
       "path": "$.pipeline[0].$match.values"
     }
   },

--- a/tests/data/variables.wallet.query.json
+++ b/tests/data/variables.wallet.query.json
@@ -4,17 +4,14 @@
   "schema": "",
   "variables": {
     "minAmount": {
-      "type": "number",
       "description": "Minimum amount filter",
       "path": "$.pipeline[0].$match.amount.$gte"
     },
     "status": {
-      "type": "string",
       "description": "Status to filter by",
       "path": "$.pipeline[0].$match.status"
     },
     "startDate": {
-      "type": "date",
       "description": "Start date filter",
       "path": "$.pipeline[0].$match.timestamp.$gte"
     }

--- a/tests/inject-variable.pipeline.test.ts
+++ b/tests/inject-variable.pipeline.test.ts
@@ -6,13 +6,10 @@ import {
   type QueryRuntimeVariables,
   validateVariables,
 } from "#/queries/queries.services";
-import type {
-  QueryArrayVariable,
-  QueryVariable,
-} from "#/queries/queries.types";
+import type { QueryVariable } from "#/queries/queries.types";
 
 function executePartialQuery(
-  queryVariables: Record<string, QueryVariable | QueryArrayVariable>,
+  queryVariables: Record<string, QueryVariable>,
   pipeline: Record<string, unknown>[],
   requestVariables: Record<string, unknown>,
 ) {
@@ -21,7 +18,7 @@ function executePartialQuery(
       validateVariables(queryVariables as Document, requestVariables),
     ),
     E.bind("pipeline", ({ variables }) =>
-      injectVariablesIntoAggregation(pipeline, variables),
+      injectVariablesIntoAggregation(queryVariables, pipeline, variables),
     ),
     E.runSync,
   );
@@ -31,7 +28,6 @@ describe("pipeline variable injection", () => {
   it("replaces simple variables", async ({ expect }) => {
     const queryVariables: Record<string, QueryVariable> = {
       address: {
-        type: "string",
         path: "$.pipeline[0].$match.wallet",
       },
     };
@@ -61,15 +57,12 @@ describe("pipeline variable injection", () => {
   it("replaces multiple variable types", async ({ expect }) => {
     const queryVariables: Record<string, QueryVariable> = {
       address: {
-        type: "string",
         path: "$.pipeline[0].$match.wallet",
       },
       value: {
-        type: "number",
         path: "$.pipeline[0].$match.amount",
       },
       isActive: {
-        type: "boolean",
         path: "$.pipeline[0].$match.active",
       },
     };
@@ -111,17 +104,14 @@ describe("pipeline variable injection", () => {
   it("replaces optional variables", async ({ expect }) => {
     const queryVariables: Record<string, QueryVariable> = {
       address: {
-        type: "string",
         path: "$.pipeline[0].$match.wallet",
         optional: true,
       },
       value: {
-        type: "number",
         path: "$.pipeline[0].$match.amount",
         optional: true,
       },
       isActive: {
-        type: "boolean",
         path: "$.pipeline[0].$match.active",
         optional: true,
       },
@@ -160,7 +150,6 @@ describe("pipeline variable injection", () => {
   it("throws error for unexpected variables", async ({ expect }) => {
     const queryVariables: Record<string, QueryVariable> = {
       address: {
-        type: "string",
         path: "$.pipeline[0].$match.wallet",
       },
     };
@@ -188,7 +177,6 @@ describe("pipeline variable injection", () => {
   it("throws error for missing variables", async ({ expect }) => {
     const queryVariables: Record<string, QueryVariable> = {
       address: {
-        type: "string",
         path: "$.pipeline[0].$match.wallet",
       },
     };
@@ -213,27 +201,21 @@ describe("pipeline variable injection", () => {
   it("handles complex pipeline with multiple stages", async ({ expect }) => {
     const queryVariables: Record<string, QueryVariable> = {
       status: {
-        type: "string",
         path: "$.pipeline[0].$match.status",
       },
       startDate: {
-        type: "string",
         path: "$.pipeline[0].$match._created.$gt",
       },
       collection: {
-        type: "string",
         path: "$.pipeline[1].$lookup.from",
       },
       localField: {
-        type: "string",
         path: "$.pipeline[1].$lookup.localField",
       },
       groupField: {
-        type: "string",
         path: "$.pipeline[3].$group._id.$concat[1]",
       },
       valueField: {
-        type: "number",
         path: "$.pipeline[3].$group.total.$sum",
       },
     };
@@ -310,23 +292,18 @@ describe("pipeline variable injection", () => {
   it("handles deeply nested structures", async ({ expect }) => {
     const queryVariables: Record<string, QueryVariable> = {
       type1: {
-        type: "string",
         path: "$.pipeline[0].$match.$or[0].type",
       },
       category1: {
-        type: "string",
         path: "$.pipeline[0].$match.$or[1].category.$in[0]",
       },
       category2: {
-        type: "string",
         path: "$.pipeline[0].$match.$or[1].category.$in[1]",
       },
       status: {
-        type: "string",
         path: "$.pipeline[0].$match.$or[2].$and[0].status",
       },
       deepValue: {
-        type: "string",
         path: "$.pipeline[0].$match.$or[2].$and[1].nested.deep.value",
       },
     };

--- a/tests/queries-variables.test.ts
+++ b/tests/queries-variables.test.ts
@@ -55,7 +55,10 @@ describe("query variable validation", () => {
     const variables = {
       minAmount: 500,
       status: "completed",
-      startDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      startDate: "2025-02-24T17:09:00.267Z",
+      // $coerce: {
+      //   startDate: "date",
+      // },
     };
 
     const response = await organization.executeQuery({

--- a/tests/queries-variables.test.ts
+++ b/tests/queries-variables.test.ts
@@ -55,10 +55,10 @@ describe("query variable validation", () => {
     const variables = {
       minAmount: 500,
       status: "completed",
-      startDate: "2025-02-24T17:09:00.267Z",
-      // $coerce: {
-      //   startDate: "date",
-      // },
+      startDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      $coerce: {
+        startDate: "date",
+      },
     };
 
     const response = await organization.executeQuery({
@@ -80,6 +80,9 @@ describe("query variable validation", () => {
       minAmount: 500,
       status: { value: "completed" },
       startDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      $coerce: {
+        startDate: "date",
+      },
     };
 
     const response = await organization.executeQuery({
@@ -96,6 +99,9 @@ describe("query variable validation", () => {
       minAmount: 500,
       status: "completed",
       startDate: null,
+      $coerce: {
+        startDate: "date",
+      },
     };
 
     const response = await organization.executeQuery({
@@ -115,6 +121,9 @@ describe("query variable validation", () => {
       minAmount: 500,
       status: "completed",
       startDate: undefined,
+      $coerce: {
+        startDate: "date",
+      },
     };
 
     const response = await organization.executeQuery({
@@ -131,6 +140,9 @@ describe("query variable validation", () => {
       minAmount: 500,
       status: "completed",
       startDate: () => new Date().toISOString(),
+      $coerce: {
+        startDate: "date",
+      },
     };
 
     const response = await organization.executeQuery({


### PR DESCRIPTION
closes #173 

This removes types from variables and items from arrays. Now the type coersions use the same mechanisms that the filters and updates in other requests. That means, runtime variables will look something like folling example when coercion is required:

```

   {
      minAmount: 500,
      status: "completed",
      startDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
      $coerce: {
        startDate: "date",
      },
    }
```

This implements also some improvements to the coercion mechanisms:
- Support for coercions to int, string, boolean. (Primitive coercions are implicit and have been moved to the coercion mechanism)
- Error handling
- Support for arrays, and not only commands in an object.

In general, the query.services has been refactored to clean the code.

Anyway, as I commented [here](https://github.com/NillionNetwork/nildb/pull/180#issuecomment-2886223116), this solution depends on the runtime variable to define the coercion type and IMO it could be error-prone.