### PR TITLE
feat: improve capability guard type inference

### DIFF
--- a/src/accounts/accounts.controllers.ts
+++ b/src/accounts/accounts.controllers.ts
@@ -1,4 +1,3 @@
-import type { NucToken } from "@nillion/nuc";
 import { Effect as E, pipe } from "effect";
 import { StatusCodes } from "http-status-codes";
 import { handleTaggedErrors } from "#/common/handler";
@@ -6,7 +5,6 @@ import { NucCmd } from "#/common/nuc-cmd-tree";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { payloadValidator } from "#/common/zod-utils";
-import type { AppContext } from "#/env";
 import {
   enforceCapability,
   RoleSchema,
@@ -15,25 +13,25 @@ import {
 import * as AccountService from "./accounts.services";
 import {
   RegisterAccountRequestSchema,
+  type RemoveAccountRequest,
   RemoveAccountRequestSchema,
+  type SetPublicKeyRequest,
   SetPublicKeyRequestSchema,
 } from "./accounts.types";
 
 export function get(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.accounts.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.accounts,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.get(
     path,
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability({
+      path,
+      cmd: NucCmd.nil.db.accounts,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account");
       return pipe(
@@ -65,19 +63,17 @@ export function register(options: ControllerOptions): void {
 export function remove(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.accounts.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.accounts,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.delete(
     path,
     payloadValidator(RemoveAccountRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: RemoveAccountRequest }>({
+      path,
+      cmd: NucCmd.nil.db.accounts,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -94,19 +90,17 @@ export function remove(options: ControllerOptions): void {
 export function setPublicKey(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.accounts.publicKey;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.accounts,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(SetPublicKeyRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: SetPublicKeyRequest }>({
+      path,
+      cmd: NucCmd.nil.db.accounts,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       // TODO: this is really replace the org owner so (a) it might need a better name
       //  and (b) should we to enforce a cooldown period or add additional protections?
@@ -125,18 +119,16 @@ export function setPublicKey(options: ControllerOptions): void {
 export function getSubscription(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.accounts.subscription;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.accounts,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.get(
     path,
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability({
+      path,
+      cmd: NucCmd.nil.db.accounts,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account");
 

--- a/src/admin/admin.controllers.data.ts
+++ b/src/admin/admin.controllers.data.ts
@@ -1,4 +1,3 @@
-import type { NucToken } from "@nillion/nuc";
 import { Effect as E, pipe } from "effect";
 import { handleTaggedErrors } from "#/common/handler";
 import { NucCmd } from "#/common/nuc-cmd-tree";
@@ -7,14 +6,19 @@ import type { ControllerOptions } from "#/common/types";
 import { payloadValidator } from "#/common/zod-utils";
 import * as DataService from "#/data/data.services";
 import {
+  type DeleteDataRequest,
   DeleteDataRequestSchema,
+  type FlushDataRequest,
   FlushDataRequestSchema,
+  type ReadDataRequest,
   ReadDataRequestSchema,
+  type TailDataRequest,
   TailDataRequestSchema,
+  type UpdateDataRequest,
   UpdateDataRequestSchema,
+  type UploadDataRequest,
   UploadDataRequestSchema,
 } from "#/data/data.types";
-import type { AppContext } from "#/env";
 import {
   enforceCapability,
   RoleSchema,
@@ -24,19 +28,17 @@ import {
 export function remove(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.data.delete;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(DeleteDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: DeleteDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -53,19 +55,17 @@ export function remove(options: ControllerOptions): void {
 export function flush(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.data.flush;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(FlushDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: FlushDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -82,19 +82,17 @@ export function flush(options: ControllerOptions): void {
 export function read(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.data.read;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(ReadDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: ReadDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -111,19 +109,17 @@ export function read(options: ControllerOptions): void {
 export function tail(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.data.tail;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(TailDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: TailDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -140,19 +136,17 @@ export function tail(options: ControllerOptions): void {
 export function update(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.data.update;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(UpdateDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: UpdateDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -169,19 +163,17 @@ export function update(options: ControllerOptions): void {
 export function upload(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.data.upload;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(UploadDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: UploadDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 

--- a/src/admin/admin.controllers.queries.ts
+++ b/src/admin/admin.controllers.queries.ts
@@ -1,4 +1,3 @@
-import type { NucToken } from "@nillion/nuc";
 import { Effect as E, pipe } from "effect";
 import { StatusCodes } from "http-status-codes";
 import { handleTaggedErrors } from "#/common/handler";
@@ -6,7 +5,6 @@ import { NucCmd } from "#/common/nuc-cmd-tree";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { payloadValidator } from "#/common/zod-utils";
-import type { AppContext } from "#/env";
 import {
   enforceCapability,
   RoleSchema,
@@ -14,28 +12,32 @@ import {
 } from "#/middleware/capability.middleware";
 import * as QueriesService from "#/queries/queries.services";
 import {
+  type DeleteQueryRequest,
   DeleteQueryRequestSchema,
+  type ExecuteQueryRequest,
   ExecuteQueryRequestSchema,
+  type QueryJobRequest,
   QueryJobRequestSchema,
 } from "#/queries/queries.types";
-import { AdminAddQueryRequestSchema } from "./admin.types";
+import {
+  type AdminAddQueryRequest,
+  AdminAddQueryRequestSchema,
+} from "./admin.types";
 
 export function add(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.queries.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(AdminAddQueryRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: AdminAddQueryRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -52,19 +54,17 @@ export function add(options: ControllerOptions): void {
 export function remove(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.queries.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.delete(
     path,
     payloadValidator(DeleteQueryRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: DeleteQueryRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -81,19 +81,17 @@ export function remove(options: ControllerOptions): void {
 export function execute(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.queries.execute;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(ExecuteQueryRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: ExecuteQueryRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -110,19 +108,17 @@ export function execute(options: ControllerOptions): void {
 export function getQueryJob(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.queries.job;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(QueryJobRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: QueryJobRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 

--- a/src/admin/admin.controllers.schemas.ts
+++ b/src/admin/admin.controllers.schemas.ts
@@ -1,41 +1,43 @@
-import type { NucToken } from "@nillion/nuc";
 import { Effect as E, pipe } from "effect";
 import { StatusCodes } from "http-status-codes";
+import type { UUID } from "mongodb";
 import { z } from "zod";
 import { handleTaggedErrors } from "#/common/handler";
 import { NucCmd } from "#/common/nuc-cmd-tree";
 import { PathsBeta, PathsV1 } from "#/common/paths";
 import { type ControllerOptions, Uuid } from "#/common/types";
 import { paramsValidator, payloadValidator } from "#/common/zod-utils";
-import type { AppContext } from "#/env";
 import {
   enforceCapability,
   RoleSchema,
   verifyNucAndLoadSubject,
 } from "#/middleware/capability.middleware";
 import * as SchemasService from "#/schemas/schemas.services";
-import { DeleteSchemaRequestSchema } from "#/schemas/schemas.types";
 import {
+  type DeleteSchemaRequest,
+  DeleteSchemaRequestSchema,
+} from "#/schemas/schemas.types";
+import {
+  type AdminAddSchemaRequest,
   AdminAddSchemaRequestSchema,
+  type CreateSchemaIndexRequest,
   CreateSchemaIndexRequestSchema,
 } from "./admin.types";
 
 export function add(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.schemas.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(AdminAddSchemaRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: AdminAddSchemaRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -52,19 +54,17 @@ export function add(options: ControllerOptions): void {
 export function remove(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.schemas.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.delete(
     path,
     payloadValidator(DeleteSchemaRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: DeleteSchemaRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
 
@@ -81,13 +81,6 @@ export function remove(options: ControllerOptions): void {
 export function metadata(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsBeta.admin.schemas.byIdMeta;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.get(
     path,
@@ -97,7 +90,12 @@ export function metadata(options: ControllerOptions): void {
       }),
     ),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ param: { id: UUID } }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("param");
 
@@ -118,13 +116,6 @@ export function metadata(options: ControllerOptions): void {
 export function createIndex(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsBeta.admin.schemas.byIdIndexes;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
@@ -135,7 +126,12 @@ export function createIndex(options: ControllerOptions): void {
       }),
     ),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: CreateSchemaIndexRequest; param: { id: UUID } }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
       const { id } = c.req.valid("param");
@@ -153,13 +149,6 @@ export function createIndex(options: ControllerOptions): void {
 export function dropIndex(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsBeta.admin.schemas.byIdIndexesByName;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.delete(
     path,
@@ -170,7 +159,12 @@ export function dropIndex(options: ControllerOptions): void {
       }),
     ),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ param: { id: UUID; name: string } }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const { id, name } = c.req.valid("param");
 

--- a/src/admin/admin.controllers.system.ts
+++ b/src/admin/admin.controllers.system.ts
@@ -1,4 +1,3 @@
-import type { NucToken } from "@nillion/nuc";
 import { Effect as E, pipe } from "effect";
 import { StatusCodes } from "http-status-codes";
 import { handleTaggedErrors } from "#/common/handler";
@@ -6,7 +5,6 @@ import { NucCmd } from "#/common/nuc-cmd-tree";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { payloadValidator } from "#/common/zod-utils";
-import type { AppContext } from "#/env";
 import {
   enforceCapability,
   RoleSchema,
@@ -14,7 +12,9 @@ import {
 } from "#/middleware/capability.middleware";
 import * as SystemService from "#/system/system.services";
 import {
+  type AdminSetLogLevelRequest,
   AdminSetLogLevelRequestSchema,
+  type AdminSetMaintenanceWindowRequest,
   AdminSetMaintenanceWindowRequestSchema,
   type LogLevelInfo,
 } from "./admin.types";
@@ -22,19 +22,17 @@ import {
 export function setMaintenanceWindow(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.system.maintenance;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(AdminSetMaintenanceWindowRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: AdminSetMaintenanceWindowRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
       return pipe(
@@ -50,18 +48,16 @@ export function setMaintenanceWindow(options: ControllerOptions): void {
 export function deleteMaintenanceWindow(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.system.maintenance;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.delete(
     path,
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) =>
       pipe(
         SystemService.deleteMaintenanceWindow(c.env),
@@ -75,19 +71,17 @@ export function deleteMaintenanceWindow(options: ControllerOptions): void {
 export function setLogLevel(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.system.logLevel;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
-    verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
     payloadValidator(AdminSetLogLevelRequestSchema),
+    verifyNucAndLoadSubject(bindings),
+    enforceCapability<{ json: AdminSetLogLevelRequest }>({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const payload = c.req.valid("json");
       c.env.log.level = payload.level;
@@ -99,18 +93,16 @@ export function setLogLevel(options: ControllerOptions): void {
 export function getLogLevel(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.admin.system.logLevel;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.admin,
-    roles: [RoleSchema.enum.admin],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.get(
     path,
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability({
+      path,
+      cmd: NucCmd.nil.db.admin,
+      roles: [RoleSchema.enum.admin],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const logLevelInfo = {
         level: c.env.log.level,

--- a/src/common/handler.ts
+++ b/src/common/handler.ts
@@ -1,4 +1,5 @@
 import { Effect as E, pipe } from "effect";
+import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { StatusCodes } from "http-status-codes";
 import { Temporal } from "temporal-polyfill";
@@ -14,7 +15,7 @@ import type {
   ResourceAccessDeniedError,
   VariableInjectionError,
 } from "#/common/errors";
-import type { AppContext } from "#/env";
+import type { AppEnv } from "#/env";
 
 export type ApiSuccessResponse<T> = {
   data: T;
@@ -39,7 +40,7 @@ type KnownError =
   | ResourceAccessDeniedError
   | VariableInjectionError;
 
-export function handleTaggedErrors(c: AppContext) {
+export function handleTaggedErrors(c: Context<AppEnv>) {
   const toResponse = (
     e: KnownError,
     statusCode: ContentfulStatusCode,

--- a/src/data/data.controllers.ts
+++ b/src/data/data.controllers.ts
@@ -1,4 +1,3 @@
-import type { NucToken } from "@nillion/nuc";
 import { Effect as E, pipe } from "effect";
 import type { OrganizationAccountDocument } from "#/accounts/accounts.types";
 import { handleTaggedErrors } from "#/common/handler";
@@ -7,7 +6,6 @@ import { enforceSchemaOwnership } from "#/common/ownership";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { payloadValidator } from "#/common/zod-utils";
-import type { AppContext } from "#/env";
 import {
   enforceCapability,
   RoleSchema,
@@ -15,30 +13,34 @@ import {
 } from "#/middleware/capability.middleware";
 import * as DataService from "./data.services";
 import {
+  type DeleteDataRequest,
   DeleteDataRequestSchema,
+  type FlushDataRequest,
   FlushDataRequestSchema,
+  type ReadDataRequest,
   ReadDataRequestSchema,
+  type TailDataRequest,
   TailDataRequestSchema,
+  type UpdateDataRequest,
   UpdateDataRequestSchema,
+  type UploadDataRequest,
   UploadDataRequestSchema,
 } from "./data.types";
 
 export function remove(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.data.delete;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.data,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(DeleteDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: DeleteDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.data,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -56,20 +58,19 @@ export function remove(options: ControllerOptions): void {
 
 export function flush(options: ControllerOptions): void {
   const { app, bindings } = options;
+
   const path = PathsV1.data.flush;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.data,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(FlushDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: FlushDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.data,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -92,19 +93,17 @@ export function flush(options: ControllerOptions): void {
 export function read(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.data.read;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.data,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(ReadDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: ReadDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.data,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -123,19 +122,17 @@ export function read(options: ControllerOptions): void {
 export function tail(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.data.tail;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.data,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(TailDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: TailDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.data,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -154,19 +151,17 @@ export function tail(options: ControllerOptions): void {
 export function update(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.data.update;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.data,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(UpdateDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: UpdateDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.data,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -189,19 +184,17 @@ export function update(options: ControllerOptions): void {
 export function upload(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.data.upload;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.data,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(UploadDataRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: UploadDataRequest }>({
+      path,
+      cmd: NucCmd.nil.db.data,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,5 @@
 import { Keypair, type NucTokenEnvelope } from "@nillion/nuc";
 import * as amqp from "amqplib";
-import type { Context } from "hono";
 import type { Db, MongoClient } from "mongodb";
 import type { Logger } from "pino";
 import { z } from "zod";
@@ -22,8 +21,6 @@ export const FeatureFlag = {
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
-
-export type AppContext = Context<AppEnv>;
 
 export type AppEnv = {
   Bindings: AppBindings;

--- a/src/middleware/maintenance.middleware.ts
+++ b/src/middleware/maintenance.middleware.ts
@@ -1,8 +1,8 @@
 import { Effect as E, pipe } from "effect";
-import type { MiddlewareHandler, Next } from "hono";
+import type { Context, MiddlewareHandler, Next } from "hono";
 import { StatusCodes } from "http-status-codes";
 import { PathsV1 } from "#/common/paths";
-import type { AppBindings, AppContext } from "#/env";
+import type { AppBindings, AppEnv } from "#/env";
 import * as SystemService from "#/system/system.services";
 
 const MAINTENANCE_EXCLUDED_PATHS: string[] = [
@@ -16,7 +16,7 @@ const MAINTENANCE_EXCLUDED_PATHS: string[] = [
 export function useMaintenanceMiddleware(
   bindings: AppBindings,
 ): MiddlewareHandler {
-  return async (c: AppContext, next: Next) => {
+  return async (c: Context<AppEnv>, next: Next) => {
     const isPathExcludedFromMaintenance = MAINTENANCE_EXCLUDED_PATHS.some(
       (path) => c.req.path.startsWith(path),
     );

--- a/src/queries/queries.controllers.ts
+++ b/src/queries/queries.controllers.ts
@@ -1,4 +1,3 @@
-import type { NucToken } from "@nillion/nuc";
 import { Effect as E, pipe } from "effect";
 import { StatusCodes } from "http-status-codes";
 import type { OrganizationAccountDocument } from "#/accounts/accounts.types";
@@ -8,7 +7,6 @@ import { enforceQueryOwnership } from "#/common/ownership";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { payloadValidator } from "#/common/zod-utils";
-import type { AppContext } from "#/env";
 import {
   enforceCapability,
   RoleSchema,
@@ -16,28 +14,30 @@ import {
 } from "#/middleware/capability.middleware";
 import * as QueriesService from "./queries.services";
 import {
+  type AddQueryRequest,
   AddQueryRequestSchema,
+  type DeleteQueryRequest,
   DeleteQueryRequestSchema,
+  type ExecuteQueryRequest,
   ExecuteQueryRequestSchema,
+  type QueryJobRequest,
   QueryJobRequestSchema,
 } from "./queries.types";
 
 export function add(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.queries.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.queries,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(AddQueryRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: AddQueryRequest }>({
+      path,
+      cmd: NucCmd.nil.db.queries,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -58,19 +58,17 @@ export function add(options: ControllerOptions): void {
 export function remove(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.queries.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.queries,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.delete(
     path,
     payloadValidator(DeleteQueryRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: DeleteQueryRequest }>({
+      path,
+      cmd: NucCmd.nil.db.queries,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -89,19 +87,17 @@ export function remove(options: ControllerOptions): void {
 export function execute(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.queries.execute;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.queries,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(ExecuteQueryRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: ExecuteQueryRequest }>({
+      path,
+      cmd: NucCmd.nil.db.queries,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");
@@ -120,18 +116,16 @@ export function execute(options: ControllerOptions): void {
 export function list(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.queries.root;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.queries,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.get(
     path,
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability({
+      path,
+      cmd: NucCmd.nil.db.queries,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
 
@@ -148,19 +142,17 @@ export function list(options: ControllerOptions): void {
 export function getQueryJob(options: ControllerOptions): void {
   const { app, bindings } = options;
   const path = PathsV1.queries.job;
-  const guard = {
-    path,
-    cmd: NucCmd.nil.db.queries,
-    roles: [RoleSchema.enum.organization],
-    // TODO: implement policy validation fix json on body type inference
-    validate: (_c: AppContext, _token: NucToken) => true,
-  };
 
   app.post(
     path,
     payloadValidator(QueryJobRequestSchema),
     verifyNucAndLoadSubject(bindings),
-    enforceCapability(bindings, guard),
+    enforceCapability<{ json: QueryJobRequest }>({
+      path,
+      cmd: NucCmd.nil.db.queries,
+      roles: [RoleSchema.enum.organization],
+      validate: (_c, _token) => true,
+    }),
     async (c) => {
       const account = c.get("account") as OrganizationAccountDocument;
       const payload = c.req.valid("json");


### PR DESCRIPTION
The primary change in this PR is in [src/middleware/capability.middleware.ts:L112](https://github.com/NillionNetwork/nildb/pull/186/files#diff-0aad4b3a11ffd9a114e0c9c40e0730244440aca459a5440006e38575a2c2cdc0R112) where the capability guard's type inference has been improved. You can see the use in any controller where it now takes a generic of type `ValidatedOutput` so that within the validate function you can now access the json | param | query bodies.