### PR TITLE
refactor(tests): update fixture setup to use unified context object and add assertion helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/swagger-ui-express": "^4.1.8",
     "@vitest/coverage-v8": "^3.1.1",
     "lefthook": "^1.11.8",
+    "pino-pretty": "^13.0.0",
     "type-fest": "^4.39.1",
     "typescript": "^5.8.3",
     "vite": "^6.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       lefthook:
         specifier: ^1.11.8
         version: 1.11.8
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.0.0
       type-fest:
         specifier: ^4.39.1
         version: 4.39.1
@@ -1221,6 +1224,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   colors@1.0.3:
     resolution: {integrity: sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==}
     engines: {node: '>=0.1.90'}
@@ -1338,6 +1344,9 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
 
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1448,6 +1457,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1527,6 +1539,9 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1540,6 +1555,9 @@ packages:
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
@@ -1696,6 +1714,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
@@ -1912,6 +1933,10 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2362,6 +2387,10 @@ packages:
   pino-http@10.4.0:
     resolution: {integrity: sha512-vjQsKBE+VN1LVchjbfLE7B6nBeGASZNRNKsR68VS0DolTm5R3zo+47JX1wjm0O96dcbvA7vnqt8YqOWlG5nN0w==}
 
+  pino-pretty@13.0.0:
+    resolution: {integrity: sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==}
+    hasBin: true
+
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
@@ -2397,6 +2426,9 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.2:
+    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2533,6 +2565,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
@@ -2664,6 +2699,10 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4231,6 +4270,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   colors@1.0.3: {}
 
   combined-stream@1.0.8:
@@ -4348,6 +4389,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.0
 
+  dateformat@4.6.3: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -4444,6 +4487,10 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.4:
+    dependencies:
+      once: 1.4.0
 
   env-paths@2.2.1: {}
 
@@ -4626,6 +4673,8 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-copy@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.2.12:
@@ -4639,6 +4688,8 @@ snapshots:
   fast-memoize@2.5.2: {}
 
   fast-redact@3.5.0: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.0.6: {}
 
@@ -4819,6 +4870,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  help-me@5.0.0: {}
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -5035,6 +5088,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@2.4.2: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -5417,6 +5472,22 @@ snapshots:
       pino-std-serializers: 7.0.0
       process-warning: 4.0.1
 
+  pino-pretty@13.0.0:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.2
+      secure-json-parse: 2.7.0
+      sonic-boom: 4.2.0
+      strip-json-comments: 3.1.1
+
   pino-std-serializers@7.0.0: {}
 
   pino@9.6.0:
@@ -5458,6 +5529,11 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  pump@3.0.2:
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -5615,6 +5691,8 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  secure-json-parse@2.7.0: {}
 
   semver@7.7.1: {}
 
@@ -5784,6 +5862,8 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
     dependencies:

--- a/tests/access-controls.test.ts
+++ b/tests/access-controls.test.ts
@@ -18,18 +18,19 @@ describe("account access controls", () => {
     schema,
     query,
   });
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
-  it("rejects unauthenticated requests", async ({ expect, admin }) => {
+  it("rejects unauthenticated requests", async ({ c }) => {
+    const { admin, expect } = c;
+
     const response = await admin.app.request(PathsV1.accounts.root);
     expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
   });
 
-  it("organizations cannot create admin accounts", async ({
-    organization,
-    expect,
-  }) => {
+  it("organizations cannot create admin accounts", async ({ c }) => {
+    const { organization, expect } = c;
+
     const keypair = Keypair.generate();
     const response = await organization.request(PathsV1.admin.accounts.root, {
       method: "POST",
@@ -44,20 +45,22 @@ describe("account access controls", () => {
     expect(response.status).toBe(StatusCodes.FORBIDDEN);
   });
 
-  it("organizations cannot list accounts", async ({ organization, expect }) => {
+  it("organizations cannot list accounts", async ({ c }) => {
+    const { organization, expect } = c;
+
     const response = await organization.request(PathsV1.admin.accounts.root);
     expect(response.status).toBe(StatusCodes.FORBIDDEN);
   });
 });
 
-describe("restrict cross organization operations", () => {
+describe("restrict cross-organization operations", () => {
   const schema = schemaJson as unknown as SchemaFixture;
   const query = queryJson as unknown as QueryFixture;
   const { it, beforeAll, afterAll } = createTestFixtureExtension({
     schema,
     query,
   });
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
   let organizationB: TestOrganizationUserClient;
   const collectionSize = 10;
@@ -95,7 +98,9 @@ describe("restrict cross organization operations", () => {
     });
   });
 
-  it("prevents data upload", async ({ expect }) => {
+  it("prevents data upload", async ({ c }) => {
+    const { expect } = c;
+
     const response = await organizationB.uploadData({
       schema: schema.id,
       data: [
@@ -106,21 +111,25 @@ describe("restrict cross organization operations", () => {
       ],
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("ResourceAccessDeniedError");
   });
 
-  it("prevents data reads", async ({ expect }) => {
+  it("prevents data reads", async ({ c }) => {
+    const { expect } = c;
+
     const response = await organizationB.readData({
       schema: schema.id,
       filter: {},
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("ResourceAccessDeniedError");
   });
 
-  it("prevents data updates", async ({ expect }) => {
+  it("prevents data updates", async ({ c }) => {
+    const { expect } = c;
+
     const record = data[Math.floor(Math.random() * collectionSize)];
     const response = await organizationB.updateData({
       schema: schema.id,
@@ -128,36 +137,42 @@ describe("restrict cross organization operations", () => {
       update: { name: "foo" },
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("ResourceAccessDeniedError");
   });
 
-  it("prevents data deletes", async ({ expect }) => {
+  it("prevents data deletes", async ({ c }) => {
+    const { expect } = c;
+
     const record = data[Math.floor(Math.random() * collectionSize)];
     const response = await organizationB.deleteData({
       schema: schema.id,
       filter: { name: record.name },
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("ResourceAccessDeniedError");
   });
 
-  it("prevents data flush", async ({ expect }) => {
+  it("prevents data flush", async ({ c }) => {
+    const { expect } = c;
+
     const response = await organizationB.flushData({
       schema: schema.id,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("ResourceAccessDeniedError");
   });
 
-  it("prevents data tail", async ({ expect }) => {
+  it("prevents data tail", async ({ c }) => {
+    const { expect } = c;
+
     const response = await organizationB.tailData({
       schema: schema.id,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("ResourceAccessDeniedError");
   });
 });

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -3,23 +3,20 @@ import { Keypair } from "@nillion/nuc";
 import { StatusCodes } from "http-status-codes";
 import { describe } from "vitest";
 import type { OrganizationAccountDocument } from "#/accounts/accounts.types";
-import type { AccountDocument } from "#/admin/admin.types";
 import { CollectionName } from "#/common/mongo";
 import { PathsV1 } from "#/common/paths";
-import { expectSuccessResponse } from "./fixture/assertions";
+import { expectAccount, expectSuccessResponse } from "./fixture/assertions";
 import { createTestFixtureExtension } from "./fixture/it";
 import { TestOrganizationUserClient } from "./fixture/test-client";
 
 describe("account management", () => {
   const { it, beforeAll, afterAll } = createTestFixtureExtension();
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
-  it("root can create an admin account without subscription", async ({
-    expect,
-    bindings,
-    root,
-  }) => {
+  it("root can create an admin account without subscription", async ({ c }) => {
+    const { root, expect } = c;
+
     const keypair = Keypair.generate();
     const did = keypair.toDidString();
 
@@ -30,17 +27,12 @@ describe("account management", () => {
     });
 
     expect(response.status).toBe(StatusCodes.CREATED);
-
-    const document = await bindings.db.primary
-      .collection<AccountDocument>(CollectionName.Accounts)
-      .findOne({ _id: did });
-    expect(document).toBeDefined;
+    await expectAccount(c, did);
   });
 
-  it("rejects requests when the subscription is inactive", async ({
-    expect,
-    organization,
-  }) => {
+  it("rejects requests when the subscription is inactive", async ({ c }) => {
+    const { organization, expect } = c;
+
     const selfSignedRootNuc = organization.nuc();
     const response = await organization.app.request(PathsV1.accounts.root, {
       headers: {
@@ -52,23 +44,22 @@ describe("account management", () => {
     expect(response.status).toBe(401);
   });
 
-  it("accepts requests when the subscription is active", async ({
-    expect,
-    organization,
-  }) => {
+  it("accepts requests when the subscription is active", async ({ c }) => {
+    const { organization, expect } = c;
+
     await organization.ensureSubscriptionActive();
 
     const response = await organization.getAccount();
-    const { data } =
-      await expectSuccessResponse<OrganizationAccountDocument>(response);
+    const { data } = await expectSuccessResponse<OrganizationAccountDocument>(
+      c,
+      response,
+    );
     expect(data._id).toBe(organization.did);
   });
 
-  it("admin can register an organization account", async ({
-    expect,
-    bindings,
-    admin,
-  }) => {
+  it("admin can register an organization account", async ({ c }) => {
+    const { admin, expect } = c;
+
     const keypair = Keypair.generate();
     const did = keypair.toDidString();
 
@@ -79,32 +70,27 @@ describe("account management", () => {
     });
 
     expect(response.status).toBe(StatusCodes.CREATED);
-
-    const document = await bindings.db.primary
-      .collection<AccountDocument>(CollectionName.Accounts)
-      .findOne({ _id: did });
-    expect(document).toBeDefined;
+    await expectAccount(c, did);
   });
 
-  it("an organization can read its profile", async ({
-    expect,
-    organization,
-  }) => {
-    const response = await organization.getAccount();
-    const data = await expectSuccessResponse(response);
+  it("an organization can read its profile", async ({ c }) => {
+    const { organization, expect } = c;
 
-    expect(data.data).toMatchObject({
+    const response = await organization.getAccount();
+    const { data } = await expectSuccessResponse<OrganizationAccountDocument>(
+      c,
+      response,
+    );
+
+    expect(data).toMatchObject({
       _id: organization.did,
       _type: "organization",
     });
   });
 
-  it("an organization can self-register", async ({
-    app,
-    bindings,
-    expect,
-    organization,
-  }) => {
+  it("an organization can self-register", async ({ c }) => {
+    const { app, bindings, organization, expect } = c;
+
     const keypair = Keypair.generate();
     const did = keypair.toDidString();
 
@@ -124,17 +110,12 @@ describe("account management", () => {
     });
 
     expect(response.status).toBe(StatusCodes.CREATED);
-
-    const document = await bindings.db.primary
-      .collection<AccountDocument>(CollectionName.Accounts)
-      .findOne({ did: newOrganization.did });
-    expect(document).toBeDefined;
+    await expectAccount(c, newOrganization.did);
   });
 
-  it("organization can update its public key", async ({
-    expect,
-    organization,
-  }) => {
+  it("an organization can update its public key", async ({ c }) => {
+    const { organization, expect } = c;
+
     const keypair = Keypair.generate();
     const updatedPublicKey = keypair.publicKey("hex");
     const response = await organization.updateAccount({
@@ -144,7 +125,7 @@ describe("account management", () => {
     expect(response.status).toBe(StatusCodes.OK);
 
     const account = await organization.getAccount();
-    const data = await expectSuccessResponse(account);
+    const data = await expectSuccessResponse(c, account);
 
     expect(data.data).toMatchObject({
       _id: organization.did,
@@ -153,12 +134,9 @@ describe("account management", () => {
     });
   });
 
-  it("admin can remove an organization account", async ({
-    expect,
-    bindings,
-    admin,
-    organization,
-  }) => {
+  it("admin can remove an organization account", async ({ c }) => {
+    const { admin, bindings, organization, expect } = c;
+
     const response = await admin.deleteAccount({
       id: organization.did,
     });

--- a/tests/coercions.test.ts
+++ b/tests/coercions.test.ts
@@ -17,8 +17,8 @@ describe("data operations", () => {
   const { it, beforeAll, afterAll } = createTestFixtureExtension({
     schema,
   });
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
   it("coerces primitive values implicitly", async ({ expect }) => {
     const _id = "string";
@@ -246,7 +246,9 @@ describe("data operations", () => {
     expect(coercedDates.$in).toStrictEqual(_created);
   });
 
-  it("coerces valid data", async ({ expect, organization, bindings }) => {
+  it("coerces valid data", async ({ c }) => {
+    const { expect, organization, bindings } = c;
+
     const testId = createUuidDto();
     const testDate = new Date().toISOString();
     const testDouble = "123.45";
@@ -264,7 +266,7 @@ describe("data operations", () => {
       data,
     });
 
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.created).toHaveLength(1);
     expect(result.data.errors).toHaveLength(0);
 
@@ -280,7 +282,9 @@ describe("data operations", () => {
     expect(document.numeric_from_string).toBe(Number(testDouble));
   });
 
-  it("rejects invalid date-time strings", async ({ expect, organization }) => {
+  it("rejects invalid date-time strings", async ({ c }) => {
+    const { expect, organization } = c;
+
     const testId = createUuidDto();
     const notADate = new Date().toISOString().split("T")[0]; // just take date
     const testDouble = "123.45";
@@ -298,7 +302,7 @@ describe("data operations", () => {
       data,
     });
 
-    const errors = await expectErrorResponse(response);
+    const errors = await expectErrorResponse(c, response);
 
     expect(errors.errors).toHaveLength(2);
     expect(errors.errors[0]).toBe("DataValidationError");
@@ -307,7 +311,9 @@ describe("data operations", () => {
     );
   });
 
-  it("rejects invalid numeric strings", async ({ expect, organization }) => {
+  it("rejects invalid numeric strings", async ({ c }) => {
+    const { expect, organization } = c;
+
     const testId = createUuidDto();
     const notADate = new Date().toISOString();
     const testDouble = "abcde"; // not numeric
@@ -325,7 +331,7 @@ describe("data operations", () => {
       data,
     });
 
-    const errors = await expectErrorResponse(response);
+    const errors = await expectErrorResponse(c, response);
 
     expect(errors.errors).toHaveLength(2);
     expect(errors.errors[0]).toBe("DataValidationError");
@@ -334,7 +340,9 @@ describe("data operations", () => {
     );
   });
 
-  it("rejects invalid uuid strings", async ({ expect, organization }) => {
+  it("rejects invalid uuid strings", async ({ c }) => {
+    const { expect, organization } = c;
+
     const testId = "xxxx-xxxx";
     const notADate = new Date().toISOString();
     const testDouble = "42";
@@ -352,7 +360,7 @@ describe("data operations", () => {
       data,
     });
 
-    const errors = await expectErrorResponse(response);
+    const errors = await expectErrorResponse(c, response);
 
     expect(errors.errors).toHaveLength(2);
     expect(errors.errors[0]).toBe("DataValidationError");

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -17,8 +17,8 @@ describe("data operations", () => {
     schema,
     query,
   });
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
   type Record = {
     _id: UuidDto;
@@ -27,7 +27,9 @@ describe("data operations", () => {
     age: number;
   };
 
-  it("can upload data", async ({ expect, bindings, organization }) => {
+  it("can upload data", async ({ c }) => {
+    const { expect, bindings, organization } = c;
+
     const data: Record[] = [
       {
         _id: createUuidDto(),
@@ -54,7 +56,7 @@ describe("data operations", () => {
       data,
     });
 
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.created).toHaveLength(3);
 
     const cursor = bindings.db.data.collection(schema.id.toString()).find({});
@@ -62,13 +64,9 @@ describe("data operations", () => {
     expect(records).toHaveLength(3);
   });
 
-  it("rejects primary key collisions", async ({
-    expect,
-    skip,
-    bindings,
-    organization,
-  }) => {
-    skip("depends on indexes, disable until index endpoint is ready");
+  it("rejects primary key collisions", async ({ skip, c }) => {
+    skip("TODO: depends on indexes, disable until index endpoint is ready");
+    const { expect, bindings, organization } = c;
 
     const data = [
       {
@@ -84,7 +82,7 @@ describe("data operations", () => {
       data,
     });
 
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.errors).toHaveLength(1);
 
     const cursor = bindings.db.data.collection(schema.id.toString()).find({});
@@ -92,8 +90,9 @@ describe("data operations", () => {
     expect(records).toHaveLength(3);
   });
 
-  it("allows for partial success", async ({ expect, skip, organization }) => {
+  it("allows for partial success", async ({ skip, c }) => {
     skip("depends on indexes, disable until index endpoint is ready");
+    const { expect, organization } = c;
 
     const data: Record[] = [
       {
@@ -115,18 +114,14 @@ describe("data operations", () => {
       data,
     });
 
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.errors).toHaveLength(1);
     expect(result.data.created).toHaveLength(1);
   });
 
-  it("rejects duplicates in data payload", async ({
-    expect,
-    skip,
-    bindings,
-    organization,
-  }) => {
+  it("rejects duplicates in data payload", async ({ skip, c }) => {
     skip("depends on indexes, disable until index endpoint is ready");
+    const { expect, organization } = c;
 
     const data: Record[] = [
       {
@@ -148,12 +143,14 @@ describe("data operations", () => {
       data,
     });
 
-    const cursor = bindings.db.data.collection(schema.id.toString()).find({});
+    const cursor = c.bindings.db.data.collection(schema.id.toString()).find({});
     const records = await cursor.toArray();
     expect(records).toHaveLength(4);
   });
 
-  it("rejects data that does not conform", async ({ expect, organization }) => {
+  it("rejects data that does not conform", async ({ c }) => {
+    const { expect, organization } = c;
+
     const data: Record[] = [
       {
         _id: createUuidDto(),
@@ -169,19 +166,20 @@ describe("data operations", () => {
       data,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
   });
 
-  it("can run a query", async ({ expect, skip, organization }) => {
+  it("can run a query", async ({ skip, c }) => {
     skip("depends on indexes, disable until index endpoint is ready");
+    const { expect, organization } = c;
 
     const response = await organization.executeQuery({
       id: query.id,
       variables: query.variables,
     });
 
-    const result = await expectSuccessResponse(response);
+    const result = await expectSuccessResponse(c, response);
     expect(result.data).toEqual([
       {
         averageAge: 30,
@@ -190,11 +188,9 @@ describe("data operations", () => {
     ]);
   });
 
-  it("can read data by a single id", async ({
-    expect,
-    bindings,
-    organization,
-  }) => {
+  it("can read data by a single id", async ({ c }) => {
+    const { expect, bindings, organization } = c;
+
     const expected = await bindings.db.data
       .collection<DataDocument>(schema.id.toString())
       .findOne({});
@@ -207,16 +203,14 @@ describe("data operations", () => {
       filter: { _id },
     });
 
-    const result = await expectSuccessResponse<Record[]>(response);
+    const result = await expectSuccessResponse<Record[]>(c, response);
     const actual = result.data[0];
     expect(actual._id).toBe(_id);
   });
 
-  it("can read data from a list of ids", async ({
-    expect,
-    bindings,
-    organization,
-  }) => {
+  it("can read data from a list of ids", async ({ c }) => {
+    const { expect, bindings, organization } = c;
+
     const expected = await bindings.db.data
       .collection<DataDocument>(schema.id.toString())
       .find({})
@@ -231,7 +225,7 @@ describe("data operations", () => {
       filter: { _id: { $in: ids } },
     });
 
-    const result = await expectSuccessResponse(response);
+    const result = await expectSuccessResponse(c, response);
     expect(result.data).toHaveLength(3);
   });
 });

--- a/tests/delete-by-filter.data.test.ts
+++ b/tests/delete-by-filter.data.test.ts
@@ -5,6 +5,7 @@ import { createUuidDto, type UuidDto } from "#/common/types";
 import queryJson from "./data/simple.query.json";
 import schemaJson from "./data/simple.schema.json";
 import {
+  assertDocumentCount,
   expectErrorResponse,
   expectSuccessResponse,
 } from "./fixture/assertions";
@@ -42,59 +43,44 @@ describe("schema data deletion", () => {
     });
   });
 
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
-  it("rejects empty filter", async ({ expect, organization }) => {
-    const filter = {};
+  it("rejects empty filter", async ({ c }) => {
+    const { organization, expect } = c;
 
     const response = await organization.deleteData({
       schema: schema.id,
-      filter,
+      filter: {},
     });
 
-    const result = await expectErrorResponse(response);
+    const result = await expectErrorResponse(c, response);
     expect(result.errors).toContain('Filter cannot be empty at "filter"');
   });
 
-  it("can remove a single match", async ({
-    expect,
-    bindings,
-    organization,
-  }) => {
-    const filter = { name: "foo" };
+  it("can remove a single match", async ({ c }) => {
+    const { organization, expect } = c;
 
     const response = await organization.deleteData({
       schema: schema.id,
-      filter,
+      filter: { name: "foo" },
     });
 
-    const result = await expectSuccessResponse<DeleteResult>(response);
+    const result = await expectSuccessResponse<DeleteResult>(c, response);
     expect(result.data.deletedCount).toBe(1);
-
-    const count = await bindings.db.data
-      .collection(schema.id.toString())
-      .countDocuments();
-    expect(count).toBe(collectionSize - 1);
+    await assertDocumentCount(c, schema.id, collectionSize - 1);
   });
 
-  it("can remove multiple matches", async ({
-    expect,
-    bindings,
-    organization,
-  }) => {
-    const filter = { name: "bar" };
+  it("can remove multiple matches", async ({ c }) => {
+    const { organization, expect } = c;
 
     const response = await organization.deleteData({
       schema: schema.id,
-      filter,
+      filter: { name: "bar" },
     });
 
-    const result = await expectSuccessResponse<DeleteResult>(response);
+    const result = await expectSuccessResponse<DeleteResult>(c, response);
     expect(result.data.deletedCount).toBe(2);
 
-    const count = await bindings.db.data
-      .collection(schema.id.toString())
-      .countDocuments();
-    expect(count).toBe(collectionSize - 3);
+    await assertDocumentCount(c, schema.id, collectionSize - 3);
   });
 });

--- a/tests/fixture/assertions.ts
+++ b/tests/fixture/assertions.ts
@@ -1,26 +1,76 @@
-import { expect } from "vitest";
+import type { UUID } from "mongodb";
+import type { AccountDocument } from "#/admin/admin.types";
 import type { ApiErrorResponse, ApiSuccessResponse } from "#/common/handler";
+import { CollectionName } from "#/common/mongo";
+import type { Did } from "#/common/types";
+import type { FixtureContext } from "./it";
 
 export function assertDefined<T>(
+  c: FixtureContext,
   value: T | undefined | null,
+  message?: string,
 ): asserts value is T {
-  expect(value).toBeDefined();
+  c.expect(
+    value,
+    message ?? "Expected value to be defined, but it was undefined",
+  ).toBeDefined();
+
+  c.expect(
+    value,
+    message ?? "Expected value to be non-null, but it was null",
+  ).not.toBeNull();
 }
 
 export async function expectSuccessResponse<T>(
+  c: FixtureContext,
   response: Response,
 ): Promise<ApiSuccessResponse<T>> {
-  expect(response.ok).toBeTruthy();
+  c.expect(
+    response.ok,
+    `Expected success response but got: code=${response.status}`,
+  ).toBeTruthy();
+
   const body = (await response.json()) as ApiSuccessResponse<T>;
-  expect(body.data).toBeDefined();
+  c.expect(body.data).toBeDefined();
   return body;
 }
 
 export async function expectErrorResponse(
+  c: FixtureContext,
   response: Response,
 ): Promise<ApiErrorResponse> {
-  expect(response.ok).toBeFalsy();
+  c.expect(
+    response.ok,
+    `Expected failure response but got: code=${response.status}`,
+  ).toBeFalsy();
+
   const body = (await response.json()) as ApiErrorResponse;
-  expect(body.errors).toBeDefined();
+  c.expect(body.errors).toBeDefined();
   return body;
+}
+
+export async function expectAccount<
+  T extends AccountDocument = AccountDocument,
+>(c: FixtureContext, did: Did): Promise<T> {
+  const document = await c.bindings.db.primary
+    .collection<AccountDocument>(CollectionName.Accounts)
+    .findOne({ _id: did });
+
+  assertDefined(c, document, `Account does not exist: did=${did}`);
+  return document as T;
+}
+
+export async function assertDocumentCount(
+  c: FixtureContext,
+  collection: UUID,
+  expected: number,
+): Promise<void> {
+  const count = await c.bindings.db.data
+    .collection(collection.toString())
+    .countDocuments();
+
+  c.expect(
+    count,
+    `Unexpected document count: collection=${collection} count=${count} expected=${expected}`,
+  ).toBe(expected);
 }

--- a/tests/fixture/assertions.ts
+++ b/tests/fixture/assertions.ts
@@ -3,7 +3,7 @@ import type { AccountDocument } from "#/admin/admin.types";
 import type { ApiErrorResponse, ApiSuccessResponse } from "#/common/handler";
 import { CollectionName } from "#/common/mongo";
 import type { Did } from "#/common/types";
-import type { FixtureContext } from "./it";
+import type { FixtureContext } from "./fixture";
 
 export function assertDefined<T>(
   c: FixtureContext,

--- a/tests/fixture/test-client.ts
+++ b/tests/fixture/test-client.ts
@@ -239,7 +239,9 @@ export class TestOrganizationUserClient extends TestClient {
           await this._options.nilauth.payAndValidate();
           return;
         } catch (_error) {
-          console.log("Retrying to pay and validate subscription after 200ms");
+          console.log(
+            "Retrying to pay and validate the subscription after 200ms",
+          );
           await new Promise((f) => setTimeout(f, 200));
         }
       }

--- a/tests/log-level.test.ts
+++ b/tests/log-level.test.ts
@@ -5,10 +5,12 @@ import { createTestFixtureExtension } from "./fixture/it";
 
 describe("log level management", () => {
   const { it, beforeAll, afterAll } = createTestFixtureExtension();
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
-  it("should return current log level", async ({ admin, bindings }) => {
+  it("should return the current log level", async ({ c }) => {
+    const { admin, bindings } = c;
+
     const response = await admin.getLogLevel();
     expect(response.status).toBe(StatusCodes.OK);
 
@@ -19,9 +21,11 @@ describe("log level management", () => {
     expect(result.levelValue).toEqual(bindings.log.levelVal);
   });
 
-  it("can set log level", async ({ admin, bindings }) => {
+  it("can set the log level", async ({ c }) => {
+    const { admin, bindings } = c;
+
     const request = {
-      level: "info",
+      level: "warn",
     } as const;
 
     const response = await admin.setLogLevel(request);

--- a/tests/maintenance.test.ts
+++ b/tests/maintenance.test.ts
@@ -1,13 +1,13 @@
 import { StatusCodes } from "http-status-codes";
 import { Temporal } from "temporal-polyfill";
-import { describe, expect } from "vitest";
+import { describe } from "vitest";
 import { expectErrorResponse } from "./fixture/assertions";
 import { createTestFixtureExtension } from "./fixture/it";
 
 describe("node maintenance window management", () => {
   const { it, beforeAll, afterAll } = createTestFixtureExtension();
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
   const start = Temporal.Now.instant();
   const end = start.add({ hours: 1 });
@@ -16,7 +16,9 @@ describe("node maintenance window management", () => {
     end: new Date(end.epochMilliseconds),
   };
 
-  it("rejects if start or end dates are invalid", async ({ expect, admin }) => {
+  it("rejects if start or end dates are invalid", async ({ c }) => {
+    const { expect, admin } = c;
+
     // End is less than start
     const invalidMaintenanceWindow = {
       start: maintenanceWindow.start,
@@ -26,7 +28,7 @@ describe("node maintenance window management", () => {
     let response = await admin.setMaintenanceWindow(invalidMaintenanceWindow);
     expect(response.status).toBe(StatusCodes.BAD_REQUEST);
 
-    let error = await expectErrorResponse(response);
+    let error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
 
     // End is same as start
@@ -35,7 +37,7 @@ describe("node maintenance window management", () => {
     response = await admin.setMaintenanceWindow(invalidMaintenanceWindow);
     expect(response.status).toBe(StatusCodes.BAD_REQUEST);
 
-    error = await expectErrorResponse(response);
+    error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
 
     // End is less than now
@@ -48,11 +50,12 @@ describe("node maintenance window management", () => {
     response = await admin.setMaintenanceWindow(invalidMaintenanceWindow);
     expect(response.status).toBe(StatusCodes.BAD_REQUEST);
 
-    error = await expectErrorResponse(response);
+    error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
   });
 
-  it("can set a maintenance window", async ({ admin }) => {
+  it("can set a maintenance window", async ({ c }) => {
+    const { expect, admin } = c;
     const response = await admin.setMaintenanceWindow({
       start: maintenanceWindow.start,
       end: maintenanceWindow.end,
@@ -61,9 +64,10 @@ describe("node maintenance window management", () => {
   });
 
   it("should return maintenance window details at `/about` when node is in maintenance", async ({
-    expect,
-    admin,
+    c,
   }) => {
+    const { expect, admin } = c;
+
     const response = await admin.about();
     expect(response.status).toBe(StatusCodes.OK);
 
@@ -80,7 +84,9 @@ describe("node maintenance window management", () => {
     expect(actualEnd).toEqual(expectedEnd.getUTCSeconds());
   });
 
-  it("can delete a maintenance window", async ({ expect, admin }) => {
+  it("can delete a maintenance window", async ({ c }) => {
+    const { expect, admin } = c;
+
     const response = await admin.deleteMaintenanceWindow();
     expect(response.status).toBe(StatusCodes.NO_CONTENT);
   });

--- a/tests/nilcomm.test.ts
+++ b/tests/nilcomm.test.ts
@@ -46,8 +46,8 @@ describe.skip("nilcomm.test.ts > blind auction", () => {
     pt: bid,
   }));
 
-  beforeAll(async (ctx) => {
-    const connection = await amqp.connect(ctx.bindings.config.mqUri);
+  beforeAll(async (c) => {
+    const connection = await amqp.connect(c.bindings.config.mqUri);
     channel = await connection.createChannel();
     await bindQueues(channel);
   });
@@ -56,10 +56,9 @@ describe.skip("nilcomm.test.ts > blind auction", () => {
     await purgeQueues(channel);
   });
 
-  it("handles secret store commands and emits stored events", async ({
-    expect,
-    bindings,
-  }) => {
+  it("handles secret store commands and emits stored events", async ({ c }) => {
+    const { expect, bindings } = c;
+
     const receivedIds = new Set<string>();
     let consumerTag = "";
 
@@ -133,10 +132,8 @@ describe.skip("nilcomm.test.ts > blind auction", () => {
     }
   });
 
-  it("stores plain text shares in the database", async ({
-    expect,
-    bindings,
-  }) => {
+  it("stores plain text shares in the database", async ({ c }) => {
+    const { expect, bindings } = c;
     // Verify all shares exist in DB
     const collection = bindings.db.data.collection<
       DocumentBase & { share: string }
@@ -152,9 +149,9 @@ describe.skip("nilcomm.test.ts > blind auction", () => {
   });
 
   it("handles the commit reveal command and emits the result ", async ({
-    expect,
-    bindings,
+    c,
   }) => {
+    const { expect, bindings } = c;
     const mapping_id = new UUID();
     let consumerTag = "";
 

--- a/tests/nucs.test.ts
+++ b/tests/nucs.test.ts
@@ -42,7 +42,7 @@ describe("nuc-based access control", () => {
   it("can setup schemas and queries", async ({ c }) => {
     const { expect, organization } = c;
 
-    const promise = registerSchemaAndQuery({ organization, schema, query });
+    const promise = registerSchemaAndQuery({ c, organization, schema, query });
     await expect(promise).resolves.not.toThrow();
 
     const response = await organization.uploadData({

--- a/tests/nucs.test.ts
+++ b/tests/nucs.test.ts
@@ -37,9 +37,11 @@ describe("nuc-based access control", () => {
   beforeAll(async ({ organization }) => {
     await organization.ensureSubscriptionActive();
   });
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
-  it("can setup schemas and queries", async ({ expect, organization }) => {
+  it("can setup schemas and queries", async ({ c }) => {
+    const { expect, organization } = c;
+
     const promise = registerSchemaAndQuery({ organization, schema, query });
     await expect(promise).resolves.not.toThrow();
 
@@ -55,17 +57,13 @@ describe("nuc-based access control", () => {
       ],
     });
 
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.created).toHaveLength(1);
   });
 
-  it("allows for delegated access (cmd: /nil/db)", async ({
-    expect,
-    app,
-    admin,
-    bindings,
-    organization,
-  }) => {
+  it("allows for delegated access (cmd: /nil/db)", async ({ c }) => {
+    const { expect, app, admin, bindings, organization } = c;
+
     // 1. The org mints a delegation nuc address to the user
     const root = await organization.getRootToken();
 
@@ -109,7 +107,7 @@ describe("nuc-based access control", () => {
     });
 
     // 5. Check the response succeeded
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.created).toHaveLength(1);
 
     // 6. Check the organisations schema to confirm the data upload
@@ -122,13 +120,9 @@ describe("nuc-based access control", () => {
     expect(documents[0]._id.toString()).toBe(body.data[0]._id);
   });
 
-  it("allows for delegated upload data (cmd: /nil/db/data)", async ({
-    expect,
-    app,
-    admin,
-    bindings,
-    organization,
-  }) => {
+  it("allows for delegated upload data (cmd: /nil/db/data)", async ({ c }) => {
+    const { expect, app, admin, bindings, organization } = c;
+
     // 1. The org mints a delegation nuc address to the user
     const root = await organization.getRootToken();
     const delegationFromBuilderRaw = NucTokenBuilder.extending(root)
@@ -171,7 +165,7 @@ describe("nuc-based access control", () => {
     });
 
     // 5. Check the response succeeded
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.created).toHaveLength(1);
 
     // 6. Check the organisations schema to confirm the data upload
@@ -192,12 +186,9 @@ describe("nuc-based access control", () => {
     expect(forbiddenResponse.status).toBe(StatusCodes.FORBIDDEN);
   });
 
-  it("allows for delegated run query (cmd: /nil/db/queries)", async ({
-    expect,
-    app,
-    admin,
-    organization,
-  }) => {
+  it("allows for delegated run query (cmd: /nil/db/queries)", async ({ c }) => {
+    const { expect, app, admin, organization } = c;
+
     // 1. The org mints a delegation nuc address to the user
     const root = await organization.getRootToken();
     const delegationFromBuilderRaw = NucTokenBuilder.extending(root)
@@ -233,15 +224,14 @@ describe("nuc-based access control", () => {
     });
 
     // 5. Check the response succeeded
-    const result =
-      await expectSuccessResponse<
-        [
-          {
-            averageAge: number;
-            count: number;
-          },
-        ]
-      >(response);
+    const result = await expectSuccessResponse<
+      [
+        {
+          averageAge: number;
+          count: number;
+        },
+      ]
+    >(c, response);
     expect(result.data[0].averageAge).toBe(10);
     expect(result.data[0].count).toBe(1);
 
@@ -255,11 +245,10 @@ describe("nuc-based access control", () => {
   });
 
   it("rejects namespace v path jumps: token.cmd=/nil/db/queries attempting to access /api/v1/data/tail)", async ({
-    expect,
-    app,
-    admin,
-    organization,
+    c,
   }) => {
+    const { expect, app, admin, organization } = c;
+
     // 1. The org mints a delegation nuc address to the user
     const root = await organization.getRootToken();
     const delegationFromBuilderRaw = NucTokenBuilder.extending(root)
@@ -296,7 +285,9 @@ describe("nuc-based access control", () => {
     expect(response.status).toBe(StatusCodes.FORBIDDEN);
   });
 
-  it("enforces revocations", async ({ expect, app, admin, organization }) => {
+  it("enforces revocations", async ({ c }) => {
+    const { expect, app, admin, organization } = c;
+
     // 1. The org mints a delegation nuc addressed to the user
     const root = await organization.getRootToken();
     const delegationFromBuilderRaw = NucTokenBuilder.extending(root)

--- a/tests/queries-array-variables.test.ts
+++ b/tests/queries-array-variables.test.ts
@@ -35,9 +35,11 @@ describe("array variable queries", () => {
     });
   });
 
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
-  it("rejects mixed-type arrays", async ({ expect, organization }) => {
+  it("rejects mixed-type arrays", async ({ c }) => {
+    const { expect, organization } = c;
+
     const variables = {
       values: [1, "string"],
     };
@@ -47,11 +49,13 @@ describe("array variable queries", () => {
       variables,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
   });
 
-  it("can execute with empty array", async ({ expect, organization }) => {
+  it("can execute with empty array", async ({ c }) => {
+    const { expect, organization } = c;
+
     const variables = {
       values: [],
     };
@@ -61,14 +65,13 @@ describe("array variable queries", () => {
       variables,
     });
 
-    const result = await expectSuccessResponse<unknown[]>(response);
+    const result = await expectSuccessResponse<unknown[]>(c, response);
     expect(result.data).toHaveLength(0);
   });
 
-  it("can use valid array of variables in pipeline", async ({
-    expect,
-    organization,
-  }) => {
+  it("can use valid array of variables in pipeline", async ({ c }) => {
+    const { expect, organization } = c;
+
     const testRecord = data[2];
     const variables = {
       values: testRecord.values,
@@ -79,7 +82,7 @@ describe("array variable queries", () => {
       variables,
     });
 
-    const result = await expectSuccessResponse<unknown[]>(response);
+    const result = await expectSuccessResponse<unknown[]>(c, response);
     expect(result.data).toHaveLength(1);
   });
 });

--- a/tests/queries-variables.test.ts
+++ b/tests/queries-variables.test.ts
@@ -32,7 +32,7 @@ describe("query variable validation", () => {
     count: number;
   };
 
-  beforeAll(async ({ organization }) => {
+  beforeAll(async (c) => {
     const data: Record[] = Array.from({ length: 10 }, () => ({
       _id: createUuidDto(),
       wallet: faker.finance.ethereumAddress(),
@@ -41,17 +41,17 @@ describe("query variable validation", () => {
       timestamp: faker.date.recent().toISOString(),
     }));
 
-    const response = await organization.uploadData({
+    const _response = await c.organization.uploadData({
       schema: schema.id,
       data,
     });
-
-    await expectSuccessResponse(response);
   });
 
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
-  it("can execute query with variables", async ({ expect, organization }) => {
+  it("can execute query with variables", async ({ c }) => {
+    const { expect, organization } = c;
+
     const variables = {
       minAmount: 500,
       status: "completed",
@@ -66,7 +66,7 @@ describe("query variable validation", () => {
       variables,
     });
 
-    const result = await expectSuccessResponse<QueryResult[]>(response);
+    const result = await expectSuccessResponse<QueryResult[]>(c, response);
 
     for (const record of result.data) {
       expect(record._id).toBe("completed");
@@ -75,7 +75,9 @@ describe("query variable validation", () => {
     }
   });
 
-  it("rejects object as variable value", async ({ expect, organization }) => {
+  it("rejects object as variable value", async ({ c }) => {
+    const { expect, organization } = c;
+
     const variables = {
       minAmount: 500,
       status: { value: "completed" },
@@ -90,11 +92,13 @@ describe("query variable validation", () => {
       variables,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
   });
 
-  it("rejects null as variable value", async ({ expect, organization }) => {
+  it("rejects null as variable value", async ({ c }) => {
+    const { expect, organization } = c;
+
     const variables = {
       minAmount: 500,
       status: "completed",
@@ -109,14 +113,13 @@ describe("query variable validation", () => {
       variables,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
   });
 
-  it("rejects undefined as variable value", async ({
-    expect,
-    organization,
-  }) => {
+  it("rejects undefined as variable value", async ({ c }) => {
+    const { expect, organization } = c;
+
     const variables = {
       minAmount: 500,
       status: "completed",
@@ -131,11 +134,13 @@ describe("query variable validation", () => {
       variables,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
   });
 
-  it("rejects function as variable value", async ({ expect, organization }) => {
+  it("rejects function as variable value", async ({ c }) => {
+    const { expect, organization } = c;
+
     const variables = {
       minAmount: 500,
       status: "completed",
@@ -150,7 +155,7 @@ describe("query variable validation", () => {
       variables,
     });
 
-    const error = await expectErrorResponse(response);
+    const error = await expectErrorResponse(c, response);
     expect(error.errors).includes("DataValidationError");
   });
 });

--- a/tests/queries.test.ts
+++ b/tests/queries.test.ts
@@ -7,7 +7,7 @@ import type { QueryDocument } from "#/queries/queries.types";
 import type { SchemaDocument } from "#/schemas/schemas.repository";
 import queryJson from "./data/simple.query.json";
 import schemaJson from "./data/simple.schema.json";
-import { assertDefined, expectSuccessResponse } from "./fixture/assertions";
+import { expectAccount, expectSuccessResponse } from "./fixture/assertions";
 import type { QueryFixture, SchemaFixture } from "./fixture/fixture";
 import { createTestFixtureExtension } from "./fixture/it";
 
@@ -21,16 +21,19 @@ describe("query.test.ts", () => {
     query.schema = schema.id;
   });
 
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
-  it("can list queries (expect 0)", async ({ expect, organization }) => {
+  it("can list queries (expect 0)", async ({ c }) => {
+    const { expect, organization } = c;
     const response = await organization.listQueries();
 
-    const result = await expectSuccessResponse<QueryDocument[]>(response);
+    const result = await expectSuccessResponse<QueryDocument[]>(c, response);
     expect(result.data).toHaveLength(0);
   });
 
-  it("can add a query", async ({ expect, organization }) => {
+  it("can add a query", async ({ c }) => {
+    const { expect, organization } = c;
+
     query.id = new UUID();
     const response = await organization.addQuery({
       _id: query.id,
@@ -43,14 +46,18 @@ describe("query.test.ts", () => {
     expect(response.status).toBe(StatusCodes.CREATED);
   });
 
-  it("can list queries (expect 1)", async ({ expect, organization }) => {
+  it("can list queries (expect 1)", async ({ c }) => {
+    const { expect, organization } = c;
+
     const response = await organization.listQueries();
 
-    const result = await expectSuccessResponse<QueryDocument[]>(response);
+    const result = await expectSuccessResponse<QueryDocument[]>(c, response);
     expect(result.data).toHaveLength(1);
   });
 
-  it("can delete a query", async ({ expect, bindings, organization }) => {
+  it("can delete a query", async ({ c }) => {
+    const { expect, bindings, organization } = c;
+
     const response = await organization.deleteQuery({
       id: query.id,
     });
@@ -63,11 +70,10 @@ describe("query.test.ts", () => {
 
     expect(queryDocument).toBeNull();
 
-    const record = await bindings.db.primary
-      .collection<OrganizationAccountDocument>(CollectionName.Accounts)
-      .findOne({ _id: organization.did });
-    assertDefined(record);
-
-    expect(record.queries).toHaveLength(0);
+    const account = await expectAccount<OrganizationAccountDocument>(
+      c,
+      organization.did,
+    );
+    expect(account.queries).toHaveLength(0);
   });
 });

--- a/tests/read.data.test.ts
+++ b/tests/read.data.test.ts
@@ -34,18 +34,22 @@ describe("data reading operations", () => {
     });
   });
 
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
-  it("can tail a collection", async ({ expect, organization }) => {
+  it("can tail a collection", async ({ c }) => {
+    const { expect, organization } = c;
+
     const response = await organization.tailData({
       schema: schema.id,
     });
 
-    const result = await expectSuccessResponse<Record[]>(response);
+    const result = await expectSuccessResponse<Record[]>(c, response);
     expect(result.data).toHaveLength(TAIL_DATA_LIMIT);
   });
 
-  it("can read data from a collection", async ({ expect, organization }) => {
+  it("can read data from a collection", async ({ c }) => {
+    const { expect, organization } = c;
+
     const testRecord = testData[Math.floor(Math.random() * collectionSize)];
 
     const response = await organization.readData({
@@ -53,7 +57,7 @@ describe("data reading operations", () => {
       filter: { name: testRecord.name },
     });
 
-    const result = await expectSuccessResponse<Record[]>(response);
+    const result = await expectSuccessResponse<Record[]>(c, response);
     expect(result.data).toHaveLength(1);
     expect(result.data[0]?._id).toBe(testRecord._id);
     expect(result.data[0]?.name).toBe(testRecord.name);

--- a/tests/schemas-datetime.test.ts
+++ b/tests/schemas-datetime.test.ts
@@ -17,10 +17,12 @@ describe("schemas.datetime.test", () => {
     schema,
     query,
   });
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
-  it("can upload date-times", async ({ expect, bindings, organization }) => {
+  it("can upload date-times", async ({ c }) => {
+    const { expect, bindings, organization } = c;
+
     const data = [
       { _id: createUuidDto(), datetime: "2024-03-19T14:30:00Z" },
       { _id: createUuidDto(), datetime: "2024-03-19T14:30:00.123Z" },
@@ -32,7 +34,7 @@ describe("schemas.datetime.test", () => {
       data,
     });
 
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.created).toHaveLength(3);
 
     const cursor = bindings.db.data.collection(schema.id.toString()).find({});
@@ -40,7 +42,9 @@ describe("schemas.datetime.test", () => {
     expect(records).toHaveLength(3);
   });
 
-  it("rejects invalid date-times", async ({ expect, organization }) => {
+  it("rejects invalid date-times", async ({ c }) => {
+    const { expect, organization } = c;
+
     const data = [
       { _id: createUuidDto(), datetime: "2024-03-19" },
       { _id: createUuidDto(), datetime: "14:30:00" },
@@ -55,19 +59,23 @@ describe("schemas.datetime.test", () => {
         data: [invalid],
       });
 
-      const result = await expectErrorResponse(response);
+      const result = await expectErrorResponse(c, response);
       expect(result.errors).includes("DataValidationError");
     }
   });
 
-  it("can run query with datetime data", async ({ expect, organization }) => {
+  it("can run query with datetime data", async ({ c }) => {
+    const { expect, organization } = c;
+
     const response = await organization.executeQuery({
       id: query.id,
       variables: query.variables,
     });
 
-    const result =
-      await expectSuccessResponse<Record<string, unknown>>(response);
+    const result = await expectSuccessResponse<Record<string, unknown>>(
+      c,
+      response,
+    );
 
     expect(result.data).toEqual([
       {

--- a/tests/system.test.ts
+++ b/tests/system.test.ts
@@ -4,15 +4,19 @@ import { createTestFixtureExtension } from "./fixture/it";
 
 describe("system.test.ts", () => {
   const { it, beforeAll, afterAll } = createTestFixtureExtension();
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
-  it("responds to health checks", async ({ expect, admin }) => {
+  it("responds to health checks", async ({ c }) => {
+    const { expect, admin } = c;
+
     const response = await admin.health();
     expect(response.ok).toBeTruthy();
   });
 
-  it("reports app version", async ({ expect, bindings, admin }) => {
+  it("reports app version", async ({ c }) => {
+    const { expect, bindings, admin } = c;
+
     const response = await admin.about();
     expect(response.ok).toBeTruthy();
 

--- a/tests/update.data.test.ts
+++ b/tests/update.data.test.ts
@@ -33,13 +33,11 @@ describe("update.data.test", () => {
     });
   });
 
-  afterAll(async (_ctx) => {});
+  afterAll(async (_c) => {});
 
-  it("can update data in a collection", async ({
-    expect,
-    bindings,
-    organization,
-  }) => {
+  it("can update data in a collection", async ({ c }) => {
+    const { expect, bindings, organization } = c;
+
     const record = data[Math.floor(Math.random() * collectionSize)];
 
     const filter = { name: record.name };
@@ -50,7 +48,7 @@ describe("update.data.test", () => {
       update,
     });
 
-    const result = await expectSuccessResponse<UpdateResult>(response);
+    const result = await expectSuccessResponse<UpdateResult>(c, response);
     expect(result.data.modifiedCount).toBe(1);
     expect(result.data.matchedCount).toBe(1);
 
@@ -58,8 +56,7 @@ describe("update.data.test", () => {
       .collection<DataDocument>(schema.id.toString())
       .findOne({ name: "foo" });
 
-    assertDefined(actual);
-
+    assertDefined(c, actual);
     expect(actual._id.toString()).toBe(record._id);
   });
 });

--- a/tests/upload-max.data.test.ts
+++ b/tests/upload-max.data.test.ts
@@ -18,8 +18,8 @@ describe("upload.max.data.test", () => {
     schema,
     query,
   });
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_c) => {});
+  afterAll(async (_c) => {});
 
   type Record = {
     _id: UuidDto;
@@ -31,10 +31,9 @@ describe("upload.max.data.test", () => {
     name: createUuidDto(),
   });
 
-  it("rejects payload that exceeds MAX_RECORDS_LENGTH", async ({
-    expect,
-    organization,
-  }) => {
+  it("rejects payload that exceeds MAX_RECORDS_LENGTH", async ({ c }) => {
+    const { expect, organization } = c;
+
     const data: Record[] = Array.from({ length: MAX_RECORDS_LENGTH + 1 }, () =>
       nextDocument(),
     );
@@ -44,16 +43,15 @@ describe("upload.max.data.test", () => {
       data,
     });
 
-    const result = await expectErrorResponse(response);
+    const result = await expectErrorResponse(c, response);
     expect(result.errors).toContain(
       'Length must be non zero and lte 10000 at "data"',
     );
   });
 
-  it("accepts payload at MAX_RECORDS_LENGTH", async ({
-    expect,
-    organization,
-  }) => {
+  it("accepts payload at MAX_RECORDS_LENGTH", async ({ c }) => {
+    const { expect, organization } = c;
+
     const data: Record[] = Array.from({ length: MAX_RECORDS_LENGTH }, () =>
       nextDocument(),
     );
@@ -63,7 +61,7 @@ describe("upload.max.data.test", () => {
       data,
     });
 
-    const result = await expectSuccessResponse<UploadResult>(response);
+    const result = await expectSuccessResponse<UploadResult>(c, response);
     expect(result.data.errors).toHaveLength(0);
     expect(result.data.created).toHaveLength(MAX_RECORDS_LENGTH);
   });


### PR DESCRIPTION
Because tests are async, importing `expect` direct from vitest means expect failures are not always associated to the failed test. This makes debugging difficult.

This change unifies the context object, and then passes that object to custom assertions so that if there is a failure it should be associated to the correct test case. This also improves and expands the assertion helpers.

Also, I've restructured the approach to logging in tests to better associate log events with their test and standardise the approach to logging.