### PR TITLE
feat!: drop manual subscriptions

### DIFF
--- a/src/accounts/accounts.controllers.ts
+++ b/src/accounts/accounts.controllers.ts
@@ -115,29 +115,3 @@ export function setPublicKey(options: ControllerOptions): void {
     },
   );
 }
-
-export function getSubscription(options: ControllerOptions): void {
-  const { app, bindings } = options;
-  const path = PathsV1.accounts.subscription;
-
-  app.get(
-    path,
-    verifyNucAndLoadSubject(bindings),
-    enforceCapability({
-      path,
-      cmd: NucCmd.nil.db.accounts,
-      roles: [RoleSchema.enum.organization],
-      validate: (_c, _token) => true,
-    }),
-    async (c) => {
-      const account = c.get("account");
-
-      return pipe(
-        AccountService.getSubscriptionState(c.env, account._id),
-        E.map((data) => c.json({ data })),
-        handleTaggedErrors(c),
-        E.runPromise,
-      );
-    },
-  );
-}

--- a/src/accounts/accounts.openapi.yaml
+++ b/src/accounts/accounts.openapi.yaml
@@ -95,29 +95,3 @@ paths:
           $ref: '../docs/base.openapi.yaml#/components/responses/401'
         '500':
           $ref: '../docs/base.openapi.yaml#/components/responses/500'
-  /api/v1/accounts/subscription:
-    get:
-      summary: Get account subscription information
-      description: Retrieve an organization's account subscription details
-      tags:
-        - Accounts
-      security:
-        - jwt: [ ]
-      responses:
-        '200':
-          description: "The organization's account subscription details"
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - did
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Account'
-        '400':
-          $ref: '../docs/base.openapi.yaml#/components/responses/400'
-        '401':
-          $ref: '../docs/base.openapi.yaml#/components/responses/401'
-        '500':
-          $ref: '../docs/base.openapi.yaml#/components/responses/500'

--- a/src/accounts/accounts.router.ts
+++ b/src/accounts/accounts.router.ts
@@ -6,5 +6,4 @@ export function buildAccountsRouter(options: ControllerOptions): void {
   AccountController.register(options);
   AccountController.remove(options);
   AccountController.setPublicKey(options);
-  AccountController.getSubscription(options);
 }

--- a/src/accounts/accounts.services.ts
+++ b/src/accounts/accounts.services.ts
@@ -1,10 +1,6 @@
 import { Effect as E, pipe } from "effect";
 import * as AdminAccountRepository from "#/admin/admin.repository";
-import type {
-  AdminCreateAccountRequest,
-  AdminSetSubscriptionStateRequest,
-} from "#/admin/admin.types";
-import { advance } from "#/common/date";
+import type { AdminCreateAccountRequest } from "#/admin/admin.types";
 import {
   type DatabaseError,
   type DataValidationError,
@@ -16,7 +12,6 @@ import type { Did } from "#/common/types";
 import type { AppBindings } from "#/env";
 import * as AccountRepository from "./accounts.repository";
 import type {
-  AccountSubscriptionDocument,
   OrganizationAccountDocument,
   RegisterAccountRequest,
 } from "./accounts.types";
@@ -69,34 +64,6 @@ export function remove(
   DocumentNotFoundError | PrimaryCollectionNotFoundError | DatabaseError
 > {
   return pipe(AccountRepository.deleteOneById(ctx, id));
-}
-
-export function setSubscriptionState(
-  ctx: AppBindings,
-  payload: AdminSetSubscriptionStateRequest,
-): E.Effect<
-  void,
-  DocumentNotFoundError | PrimaryCollectionNotFoundError | DatabaseError
-> {
-  const {
-    did,
-    start = new Date(),
-    end = advance(start, 30),
-    txHash = "",
-  } = payload;
-  return pipe(
-    AccountRepository.setSubscriptionState(ctx, did, start, end, txHash),
-  );
-}
-
-export function getSubscriptionState(
-  ctx: AppBindings,
-  did: Did,
-): E.Effect<
-  AccountSubscriptionDocument,
-  DocumentNotFoundError | PrimaryCollectionNotFoundError | DatabaseError
-> {
-  return AccountRepository.getSubscriptionState(ctx, did);
 }
 
 export function setPublicKey(

--- a/src/accounts/accounts.types.ts
+++ b/src/accounts/accounts.types.ts
@@ -31,13 +31,6 @@ export const RemoveAccountRequestSchema = z.object({
 export type RemoveAccountRequest = z.infer<typeof RemoveAccountRequestSchema>;
 export type RemoveAccountResponse = ApiResponse<string>;
 
-export type AccountSubscriptionDocument = {
-  active: boolean;
-  start: Date;
-  end: Date;
-  txHash: string;
-};
-
 /**
  * Repository types
  */
@@ -47,11 +40,6 @@ export type OrganizationAccountDocument = {
   _created: Date;
   _updated: Date;
   name: string;
-  subscription: {
-    start: Date;
-    end: Date;
-    txHash: string;
-  };
   schemas: UUID[];
   queries: UUID[];
 };

--- a/src/admin/admin.controllers.accounts.ts
+++ b/src/admin/admin.controllers.accounts.ts
@@ -1,12 +1,11 @@
 import { Effect as E, pipe } from "effect";
 import { StatusCodes } from "http-status-codes";
-import { z } from "zod";
 import * as AccountService from "#/accounts/accounts.services";
 import { handleTaggedErrors } from "#/common/handler";
 import { NucCmd } from "#/common/nuc-cmd-tree";
 import { PathsV1 } from "#/common/paths";
-import { type ControllerOptions, type Did, DidSchema } from "#/common/types";
-import { paramsValidator, payloadValidator } from "#/common/zod-utils";
+import type { ControllerOptions } from "#/common/types";
+import { payloadValidator } from "#/common/zod-utils";
 import {
   enforceCapability,
   RoleSchema,
@@ -18,8 +17,6 @@ import {
   AdminCreateAccountRequestSchema,
   type AdminDeleteAccountRequest,
   AdminDeleteAccountRequestSchema,
-  type AdminSetSubscriptionStateRequest,
-  AdminSetSubscriptionStateRequestSchema,
 } from "./admin.types";
 
 export function create(options: ControllerOptions): void {
@@ -93,68 +90,6 @@ export function list(options: ControllerOptions): void {
       return pipe(
         AdminService.listAllAccounts(c.env),
         E.map((data) => c.json({ data })),
-        handleTaggedErrors(c),
-        E.runPromise,
-      );
-    },
-  );
-}
-
-export function setSubscriptionState(options: ControllerOptions): void {
-  const { app, bindings } = options;
-  const path = PathsV1.admin.accounts.subscription;
-
-  app.post(
-    path,
-    payloadValidator(AdminSetSubscriptionStateRequestSchema),
-    verifyNucAndLoadSubject(bindings),
-    enforceCapability<{ json: AdminSetSubscriptionStateRequest }>({
-      path,
-      cmd: NucCmd.nil.db.admin,
-      roles: [RoleSchema.enum.admin],
-      validate: (_c, _token) => true,
-    }),
-    async (c) => {
-      const payload = c.req.valid("json");
-
-      return pipe(
-        AccountService.setSubscriptionState(c.env, payload),
-        E.map(() => new Response(null, { status: StatusCodes.OK })),
-        handleTaggedErrors(c),
-        E.runPromise,
-      );
-    },
-  );
-}
-
-export function getSubscriptionState(options: ControllerOptions): void {
-  const { app, bindings } = options;
-  const path = PathsV1.admin.accounts.subscriptionByDid;
-
-  app.get(
-    path,
-    paramsValidator(
-      z.object({
-        did: DidSchema,
-      }),
-    ),
-    verifyNucAndLoadSubject(bindings),
-    enforceCapability<{ param: { did: Did } }>({
-      path,
-      cmd: NucCmd.nil.db.admin,
-      roles: [RoleSchema.enum.admin],
-      validate: (_c, _token) => true,
-    }),
-    async (c) => {
-      const payload = c.req.valid("param");
-
-      return pipe(
-        AccountService.getSubscriptionState(c.env, payload.did),
-        E.map((data) =>
-          c.json({
-            data,
-          }),
-        ),
         handleTaggedErrors(c),
         E.runPromise,
       );

--- a/src/admin/admin.router.ts
+++ b/src/admin/admin.router.ts
@@ -9,8 +9,6 @@ export function buildAdminRouter(options: ControllerOptions): void {
   AdminAccountsControllers.create(options);
   AdminAccountsControllers.remove(options);
   AdminAccountsControllers.list(options);
-  AdminAccountsControllers.setSubscriptionState(options);
-  AdminAccountsControllers.getSubscriptionState(options);
 
   AdminDataControllers.remove(options);
   AdminDataControllers.flush(options);

--- a/src/admin/admin.types.ts
+++ b/src/admin/admin.types.ts
@@ -24,16 +24,6 @@ export type AdminDeleteAccountRequest = z.infer<
   typeof AdminDeleteAccountRequestSchema
 >;
 
-export const AdminSetSubscriptionStateRequestSchema = z.object({
-  did: DidSchema,
-  start: z.coerce.date().optional(),
-  end: z.coerce.date().optional(),
-  txHash: z.string().optional(),
-});
-export type AdminSetSubscriptionStateRequest = z.infer<
-  typeof AdminSetSubscriptionStateRequestSchema
->;
-
 export const AdminAddQueryRequestSchema = AddQueryRequestSchema.extend({
   owner: DidSchema,
 });

--- a/src/common/paths.ts
+++ b/src/common/paths.ts
@@ -4,7 +4,7 @@ export const PathSchema = z
   .string()
   .startsWith("/")
   .regex(/^(\/[a-z0-9_:.-]+)+$/i, {
-    message: "Path must follow format: /parent/child/:param/grandchild",
+    message: "Path must follow the format: /parent/child/:param/grandchild",
   })
   .brand<"path">();
 
@@ -14,16 +14,11 @@ export const PathsV1 = {
   accounts: {
     root: PathSchema.parse("/api/v1/accounts"),
     publicKey: PathSchema.parse("/api/v1/accounts/public_key"),
-    subscription: PathSchema.parse("/api/v1/accounts/subscription"),
   },
   admin: {
     root: PathSchema.parse("/api/v1/admin"),
     accounts: {
       root: PathSchema.parse("/api/v1/admin/accounts"),
-      subscription: PathSchema.parse("/api/v1/admin/accounts/subscription"),
-      subscriptionByDid: PathSchema.parse(
-        "/api/v1/admin/accounts/subscription/:did",
-      ),
     },
     data: {
       delete: PathSchema.parse("/api/v1/admin/data/delete"),

--- a/src/middleware/capability.middleware.ts
+++ b/src/middleware/capability.middleware.ts
@@ -103,9 +103,9 @@ export function verifyNucAndLoadSubject<
       return next();
     } catch (cause) {
       if (cause && typeof cause === "object" && "message" in cause) {
-        log.error("Auth error: %O", cause);
+        log.error({ cause: cause.message }, "Auth error");
       } else {
-        log.error("Auth error: unknown");
+        log.error({ cause: "unknown" }, "Auth error");
       }
       return c.text(
         getReasonPhrase(StatusCodes.UNAUTHORIZED),

--- a/tests/fixture/test-client.ts
+++ b/tests/fixture/test-client.ts
@@ -20,7 +20,6 @@ import type {
   AdminDeleteAccountRequest,
   AdminSetLogLevelRequest,
   AdminSetMaintenanceWindowRequest,
-  AdminSetSubscriptionStateRequest,
 } from "#/admin/admin.types";
 import type { App } from "#/app";
 import { PathsBeta, PathsV1 } from "#/common/paths";
@@ -132,21 +131,6 @@ export class TestAdminUserClient extends TestRootUserClient {
       method: "DELETE",
       body,
     });
-  }
-
-  async setSubscriptionState(
-    body: AdminSetSubscriptionStateRequest,
-  ): Promise<Response> {
-    return this.request(PathsV1.admin.accounts.subscription, {
-      method: "POST",
-      body,
-    });
-  }
-
-  async getSubscriptionState(did: DidString): Promise<Response> {
-    return this.request(
-      PathsV1.admin.accounts.subscriptionByDid.replace(":did", did),
-    );
   }
 
   async setMaintenanceWindow(
@@ -297,10 +281,6 @@ export class TestOrganizationUserClient extends TestClient {
 
   async getAccount(): Promise<Response> {
     return this.request(PathsV1.accounts.root);
-  }
-
-  async getSubscriptionState(): Promise<Response> {
-    return this.request(PathsV1.accounts.subscription);
   }
 
   async updateAccount(body: SetPublicKeyRequest): Promise<Response> {


### PR DESCRIPTION
Since invocation NUCs need to be signed by nilAuth, subscriptions are now encoded directly in the NUC's proof chain and so manual subscription states are no longer required.

Closes #194 
