### PR TITLE
chore: remove inline `TODO` comments and create corresponding gh issues

### DIFF
--- a/src/collections/collections.controllers.ts
+++ b/src/collections/collections.controllers.ts
@@ -203,8 +203,6 @@ export function readCollectionById(options: ControllerOptions): void {
       const builder = c.get("builder") as BuilderDocument;
       const payload = c.req.valid("param");
 
-      // TODO: needs to include metadata with result
-
       return pipe(
         enforceCollectionOwnership(builder, payload.id),
         E.flatMap(() =>

--- a/src/data/data.services.ts
+++ b/src/data/data.services.ts
@@ -179,7 +179,6 @@ export function deleteData(
     );
   };
 
-  // TODO: only invoke the owned check if its an owned collection
   return pipe(
     DataRepository.findMany(ctx, command.collection, command.filter),
     E.map((documents) => groupByOwner(documents)),

--- a/src/users/users.controllers.ts
+++ b/src/users/users.controllers.ts
@@ -159,10 +159,8 @@ export function readData(options: ControllerOptions): void {
       const command = UserDataMapper.toFindDataCommand(user, params);
 
       return pipe(
-        // TODO: Do we want to simply have _owner as part of the query or do we want to do enforcement?
         DataService.readRecords(c.env, command),
         E.map((documents) => documents as OwnedDocumentBase[]),
-        // TODO: This should return 1 document or null ... need to deal with this more elegantly
         E.map((document) => UserDataMapper.toReadDataResponse(document)),
         E.map((response) => c.json(response)),
         handleTaggedErrors(c),
@@ -289,8 +287,6 @@ export function revokeAccess(options: ControllerOptions): void {
       const user = c.get("user");
       const payload = c.req.valid("json");
       const command = UserDataMapper.toRevokeDataAccessCommand(user, payload);
-
-      // TODO: What should happen if the user revokes permissions for the schema owner?
 
       return pipe(
         enforceDataOwnership(user, command.document, command.collection),

--- a/src/users/users.dto.ts
+++ b/src/users/users.dto.ts
@@ -37,7 +37,6 @@ const UserProfileData = z.object({
         col: z.string().uuid(),
         op: z.string(),
       })
-      // TODO: capture acl type
       .passthrough(),
   ),
   data: z.array(

--- a/src/users/users.mapper.ts
+++ b/src/users/users.mapper.ts
@@ -49,7 +49,6 @@ export const UserDataMapper = {
         _id: user._id,
         _created: user._created.toISOString(),
         _updated: user._updated.toISOString(),
-        // TODO: if op = "auth" then acl should be returned
         log: user.log.map((l) => ({ col: l.col.toString(), op: l.op })),
         data: user.data.map((d) => ({
           collection: d.collection.toString(),

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -41,8 +41,6 @@ export function upsert(
   const filter: StrictFilter<UserDocument> = { _id: user };
 
   const logOperations: LogOperation[] = [];
-  // TODO: Clarify why these are distinct ... eg why is acl both a write + auth operation?
-  // Add write operations for each document
   for (const col of data) {
     logOperations.push({ op: "write", col });
   }
@@ -183,7 +181,7 @@ export function addAclEntry(
   };
 
   const update: StrictUpdateFilter<OwnedDocumentBase> = {
-    // @ts-expect-error TODO: investigate how to type $push
+    // @ts-expect-error
     $push: { _acl: acl },
   };
 
@@ -220,7 +218,7 @@ export function removeAclEntry(
   };
 
   const update: UpdateFilter<OwnedDocumentBase> = {
-    // @ts-expect-error TODO: investigate how to type $pull
+    // @ts-expect-error
     $pull: { _acl: { grantee } },
   };
 

--- a/tests/access-controls.test.ts
+++ b/tests/access-controls.test.ts
@@ -12,7 +12,6 @@ import {
   createBuilderTestClient,
 } from "./fixture/test-client";
 
-// TODO(tim): revisit once we start enforcing Nuc policies
 describe("access-controls", () => {
   const collection = collectionJson as unknown as CollectionFixture;
   const query = queryJson as unknown as QueryFixture;

--- a/tests/delete-by-filter.data.test.ts
+++ b/tests/delete-by-filter.data.test.ts
@@ -56,11 +56,7 @@ describe("delete-by-filter.data.test.ts", () => {
         collection: collection.id,
         filter: {},
       })
-      .expectFailure(
-        StatusCodes.BAD_REQUEST,
-        // TODO: disabled until we correctly unpack the zod error message
-        // 'Filter cannot be empty at "filter"',
-      );
+      .expectFailure(StatusCodes.BAD_REQUEST);
   });
 
   it("can remove a single match", async ({ c }) => {

--- a/tests/fixture/test-client.ts
+++ b/tests/fixture/test-client.ts
@@ -697,12 +697,6 @@ export class UserTestClient extends BaseTestClient {
     const audience = Did.fromHex(this._options.nodePublicKey);
     const subject = Did.fromHex(this.keypair.publicKey("hex"));
 
-    // If a builder delegation is set, use it; otherwise create self-signed token
-    if (this.options.builderDelegation) {
-      // TODO: Implement delegation token usage
-      // For now, fall back to self-signed token
-    }
-
     return NucTokenBuilder.invocation({})
       .command(NucCmd.nil.db.users.root)
       .audience(audience)

--- a/tests/owned-data.test.ts
+++ b/tests/owned-data.test.ts
@@ -64,8 +64,7 @@ describe("owned-data.test.ts", () => {
     expect(records).toHaveLength(3);
   });
 
-  // it.skip("rejects primary key collisions", async ({ skip, c }) => {
-  //   skip("TODO: depends on indexes, disable until index endpoint is ready");
+  // it.skip("rejects primary key collisions", async ({ c }) => {
   //   const { expect, bindings, builder, user } = c;
   //
   //   const data = [

--- a/tests/standard-data.test.ts
+++ b/tests/standard-data.test.ts
@@ -66,8 +66,7 @@ describe("standard-data.test.ts", () => {
     expect(records).toHaveLength(3);
   });
 
-  it.skip("rejects primary key collisions", async ({ skip, c }) => {
-    skip("TODO: depends on indexes, disable until index endpoint is ready");
+  it.skip("rejects primary key collisions", async ({ c }) => {
     const { expect, bindings, builder } = c;
 
     const data = [


### PR DESCRIPTION
Inline todos can be confusing because the state of these inline todos is unclear and there is no clean tracking. We should always look to capture TODOs in a git issue (pretty sure all of these todos are mine 😂 ). The removes all inline TODO comments and created issues:

- #241
- #242 
- #243 
- #244 
- #245
- #246 
- #247