### PR TITLE
chore(users): migrate owned-data tests

### DIFF
--- a/src/common/ownership.ts
+++ b/src/common/ownership.ts
@@ -48,8 +48,8 @@ export function enforceCollectionOwnership(
 
 export function enforceDataOwnership(
   user: UserDocument,
-  document: UUID | string,
-  collection: UUID | string,
+  document: UUID,
+  collection: UUID,
 ): E.Effect<void, ResourceAccessDeniedError> {
   return pipe(
     E.succeed(

--- a/src/users/users.controllers.ts
+++ b/src/users/users.controllers.ts
@@ -161,7 +161,7 @@ export function readData(options: ControllerOptions): void {
       const command = UserDataMapper.toFindDataCommand(user, params);
 
       return pipe(
-        enforceDataOwnership(user, params.document, params.collection),
+        enforceDataOwnership(user, command.document, command.collection),
         E.flatMap(() => DataService.readRecords(c.env, command)),
         E.map((documents) => documents as OwnedDocumentBase[]),
         E.map((document) => UserDataMapper.toReadDataResponse(document)),

--- a/src/users/users.mapper.ts
+++ b/src/users/users.mapper.ts
@@ -1,6 +1,6 @@
 import { UUID } from "mongodb";
 import { Did } from "#/common/types";
-import type { FindDataCommand, OwnedDocumentBase } from "#/data/data.types";
+import type { OwnedDocumentBase } from "#/data/data.types";
 import type {
   DeleteDocumentRequestParams,
   GrantAccessToDataRequest,
@@ -18,6 +18,7 @@ import type {
   DeleteDataCommand,
   GrantAccessToDataCommand,
   ReadDataAclCommand,
+  ReadDataCommand,
   RevokeAccessToDataCommand,
   UserDocument,
 } from "./users.types";
@@ -142,8 +143,9 @@ export const UserDataMapper = {
   toFindDataCommand(
     user: UserDocument,
     body: ReadDataRequestParams,
-  ): FindDataCommand {
+  ): ReadDataCommand {
     return {
+      document: new UUID(body.document),
       collection: new UUID(body.collection),
       filter: {
         _id: new UUID(body.document),

--- a/src/users/users.types.ts
+++ b/src/users/users.types.ts
@@ -1,6 +1,7 @@
 import type { UUID } from "mongodb";
 import type { DocumentBase } from "#/common/mongo";
 import type { Did } from "#/common/types";
+import type { FindDataCommand } from "#/data/data.types";
 
 /**
  * Access control list entry.
@@ -44,6 +45,13 @@ export type DataDocumentReference = {
 export type UserDocument = DocumentBase<Did> & {
   data: DataDocumentReference[];
   log: LogOperation[];
+};
+
+/**
+ * Read data command.
+ */
+export type ReadDataCommand = FindDataCommand & {
+  document: UUID;
 };
 
 /**

--- a/tests/owned-data.test.ts
+++ b/tests/owned-data.test.ts
@@ -71,7 +71,7 @@ describe("owned-data.test.ts", () => {
   });
 
   it("rejects primary key collisions", async ({ skip, c }) => {
-    skip("TODO: depends on indexes, disable until index endpoint is ready");
+    skip("depends on indexes, disable until index endpoint is ready");
     const { expect, bindings, builder, user } = c;
 
     const data = [


### PR DESCRIPTION
closes #254 

In addition, this force owned data ownership, it's needed to avoid user can read other users' data. This is related to #247 