### PR TITLE
refactor: clarify ownership enforcement and permission edge cases

### DIFF
--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -131,3 +131,12 @@ export class TimeoutError extends Data.TaggedError("TimeoutError")<{
     return [this._tag, this.message];
   }
 }
+
+export class RevokeAccessError extends Data.TaggedError("RevokeAccessError")<{
+  type: string;
+  id: string;
+}> {
+  humanize(): string[] {
+    return [this._tag, `type: ${this.type}`, `object: ${this.id}`];
+  }
+}

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -3,6 +3,7 @@ import type { JsonObject } from "type-fest";
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
 import type { Did } from "#/common/types";
+import type { Acl } from "#/users/users.types";
 
 export class DuplicateEntryError extends Data.TaggedError(
   "DuplicateEntryError",
@@ -132,11 +133,33 @@ export class TimeoutError extends Data.TaggedError("TimeoutError")<{
   }
 }
 
+export class GrantAccessError extends Data.TaggedError("GrantAccessError")<{
+  type: string;
+  id: string;
+  acl: Acl;
+}> {
+  humanize(): string[] {
+    return [
+      this._tag,
+      `type: ${this.type}`,
+      `object: ${this.id}`,
+      `grantee: ${this.acl.grantee}`,
+      `${this.acl}: [r=${this.acl.read}, w=${this.acl.write}, x=${this.acl.execute}]`,
+    ];
+  }
+}
+
 export class RevokeAccessError extends Data.TaggedError("RevokeAccessError")<{
   type: string;
   id: string;
+  grantee: Did;
 }> {
   humanize(): string[] {
-    return [this._tag, `type: ${this.type}`, `object: ${this.id}`];
+    return [
+      this._tag,
+      `type: ${this.type}`,
+      `object: ${this.id}`,
+      `grantee: ${this.grantee}`,
+    ];
   }
 }

--- a/src/common/handler.ts
+++ b/src/common/handler.ts
@@ -10,6 +10,7 @@ import type {
   DataValidationError,
   DocumentNotFoundError,
   DuplicateEntryError,
+  GrantAccessError,
   IndexNotFoundError,
   InvalidIndexOptionsError,
   ResourceAccessDeniedError,
@@ -47,6 +48,7 @@ type KnownError =
   | InvalidIndexOptionsError
   | ResourceAccessDeniedError
   | VariableInjectionError
+  | GrantAccessError
   | RevokeAccessError;
 
 export function handleTaggedErrors(c: Context<AppEnv>) {
@@ -81,6 +83,7 @@ export function handleTaggedErrors(c: Context<AppEnv>) {
         InvalidIndexOptionsError: (e) => toResponse(e, StatusCodes.BAD_REQUEST),
         ResourceAccessDeniedError: (e) => toResponse(e, StatusCodes.NOT_FOUND),
         VariableInjectionError: (e) => toResponse(e, StatusCodes.BAD_REQUEST),
+        GrantAccessError: (e) => toResponse(e, StatusCodes.UNAUTHORIZED),
         RevokeAccessError: (e) => toResponse(e, StatusCodes.UNAUTHORIZED),
       }),
     );

--- a/src/common/handler.ts
+++ b/src/common/handler.ts
@@ -13,6 +13,7 @@ import type {
   IndexNotFoundError,
   InvalidIndexOptionsError,
   ResourceAccessDeniedError,
+  RevokeAccessError,
   VariableInjectionError,
 } from "#/common/errors";
 import type { AppEnv } from "#/env";
@@ -45,7 +46,8 @@ type KnownError =
   | IndexNotFoundError
   | InvalidIndexOptionsError
   | ResourceAccessDeniedError
-  | VariableInjectionError;
+  | VariableInjectionError
+  | RevokeAccessError;
 
 export function handleTaggedErrors(c: Context<AppEnv>) {
   const toResponse = (
@@ -79,6 +81,7 @@ export function handleTaggedErrors(c: Context<AppEnv>) {
         InvalidIndexOptionsError: (e) => toResponse(e, StatusCodes.BAD_REQUEST),
         ResourceAccessDeniedError: (e) => toResponse(e, StatusCodes.NOT_FOUND),
         VariableInjectionError: (e) => toResponse(e, StatusCodes.BAD_REQUEST),
+        RevokeAccessError: (e) => toResponse(e, StatusCodes.UNAUTHORIZED),
       }),
     );
 }

--- a/src/common/ownership.ts
+++ b/src/common/ownership.ts
@@ -1,7 +1,7 @@
 import { Effect as E, pipe } from "effect";
 import type { UUID } from "mongodb";
 import type { BuilderDocument } from "#/builders/builders.types";
-import { ResourceAccessDeniedError } from "#/common/errors";
+import { ResourceAccessDeniedError, RevokeAccessError } from "#/common/errors";
 import type { UserDocument } from "#/users/users.types";
 
 export function enforceQueryOwnership(
@@ -67,6 +67,27 @@ export function enforceDataOwnership(
               type: "collection",
               id: document.toString(),
               user: user._id,
+            }),
+          );
+    }),
+  );
+}
+
+export function checkRevokeAccess(
+  builder: BuilderDocument,
+  document: UUID,
+): E.Effect<void, RevokeAccessError> {
+  return pipe(
+    E.succeed(
+      builder.collections.some((s) => s.toString() === document.toString()),
+    ),
+    E.flatMap((isOwner) => {
+      return !isOwner
+        ? E.succeed(void 0)
+        : E.fail(
+            new RevokeAccessError({
+              type: "collection",
+              id: document.toString(),
             }),
           );
     }),

--- a/src/data/data.controllers.ts
+++ b/src/data/data.controllers.ts
@@ -153,7 +153,7 @@ export function findData(options: ControllerOptions): void {
 
       return pipe(
         enforceCollectionOwnership(builder, command.collection),
-        E.flatMap(() => DataService.readRecords(c.env, command)),
+        E.flatMap(() => DataService.findRecords(c.env, command)),
         E.map((documents) => DataMapper.toFindDataResponse(documents)),
         E.map((response) => c.json<FindDataResponse>(response)),
         handleTaggedErrors(c),

--- a/src/data/data.controllers.ts
+++ b/src/data/data.controllers.ts
@@ -1,11 +1,15 @@
 import { Effect as E, pipe } from "effect";
 import { describeRoute } from "hono-openapi";
 import { resolver, validator as zValidator } from "hono-openapi/zod";
+import * as BuildersService from "#/builders/builders.services";
 import type { BuilderDocument } from "#/builders/builders.types";
 import { handleTaggedErrors } from "#/common/handler";
 import { NucCmd } from "#/common/nuc-cmd-tree";
 import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
-import { enforceCollectionOwnership } from "#/common/ownership";
+import {
+  checkGrantAccess,
+  enforceCollectionOwnership,
+} from "#/common/ownership";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import {
@@ -293,6 +297,10 @@ export function createOwnedData(options: ControllerOptions): void {
 
       return pipe(
         enforceCollectionOwnership(builder, command.collection),
+        E.flatMap(() => BuildersService.find(c.env, command.acl.grantee)),
+        E.flatMap((builder) =>
+          checkGrantAccess(builder, command.collection, command.acl),
+        ),
         E.flatMap(() => DataService.createOwnedRecords(c.env, command)),
         E.map((result) => DataMapper.toCreateDataResponse(result)),
         E.map((response) => c.json<CreateDataResponse>(response)),

--- a/src/data/data.mapper.ts
+++ b/src/data/data.mapper.ts
@@ -58,13 +58,6 @@ export const DataMapper = {
   },
 
   /**
-   * Converts array of data documents to find response.
-   */
-  toFindDataResponse(documents: DocumentBase[]): FindDataResponse {
-    return { data: documents };
-  },
-
-  /**
    * Converts MongoDB delete result to response.
    */
   toDeleteDataResponse(result: DeleteResult): DeleteDataResponse {
@@ -140,6 +133,13 @@ export const DataMapper = {
       collection: new UUID(dto.collection),
       filter: dto.filter,
     };
+  },
+
+  /**
+   * Converts array of data documents to find response.
+   */
+  toFindDataResponse(documents: DocumentBase[]): FindDataResponse {
+    return { data: documents };
   },
 
   /**

--- a/src/data/data.services.ts
+++ b/src/data/data.services.ts
@@ -154,8 +154,10 @@ export function updateRecords(
   };
   return pipe(
     DataRepository.findMany(ctx, collection, filter),
+    // This returns the owned documents grouped by owner, the standard documents are skipped.
     E.map((documents) => groupByOwner(documents)),
-    E.flatMap((documents) => updateUserLogs(documents)),
+    E.flatMap((ownedDocuments) => updateUserLogs(ownedDocuments)),
+    // This updates both owned and standard documents.
     E.flatMap(() => DataRepository.updateMany(ctx, collection, filter, update)),
   );
 }
@@ -197,8 +199,10 @@ export function deleteData(
 
   return pipe(
     DataRepository.findMany(ctx, command.collection, command.filter),
+    // This returns the owned documents grouped by owner, the standard documents are skipped.
     E.map((documents) => groupByOwner(documents)),
-    E.flatMap((documents) => deleteAllUserDataReferences(documents)),
+    E.flatMap((ownedDocuments) => deleteAllUserDataReferences(ownedDocuments)),
+    // This updates both owned and standard documents.
     E.flatMap(() =>
       DataRepository.deleteMany(ctx, command.collection, command.filter),
     ),

--- a/src/data/data.services.ts
+++ b/src/data/data.services.ts
@@ -22,6 +22,7 @@ import type {
   FlushDataCommand,
   OwnedDocumentBase,
   PartialDataDocumentDto,
+  ReadDataCommand,
   RecentDataCommand,
   StandardDocumentBase,
   UpdateDataCommand,
@@ -163,9 +164,25 @@ export function updateRecords(
 }
 
 /**
- * Read records.
+ * Read record.
  */
-export function readRecords(
+export function readRecord(
+  ctx: AppBindings,
+  command: ReadDataCommand,
+): E.Effect<
+  DocumentBase,
+  | DocumentNotFoundError
+  | CollectionNotFoundError
+  | DatabaseError
+  | DataValidationError
+> {
+  return DataRepository.findOne(ctx, command.collection, command.filter);
+}
+
+/**
+ * Find records.
+ */
+export function findRecords(
   ctx: AppBindings,
   command: FindDataCommand,
 ): E.Effect<

--- a/src/data/data.types.ts
+++ b/src/data/data.types.ts
@@ -71,6 +71,15 @@ export type UpdateDataCommand = {
 };
 
 /**
+ * Read data command.
+ */
+export type ReadDataCommand = {
+  document: UUID;
+  collection: UUID;
+  filter: Record<string, unknown>;
+};
+
+/**
  * Find data command.
  */
 export type FindDataCommand = {

--- a/src/users/users.controllers.ts
+++ b/src/users/users.controllers.ts
@@ -152,12 +152,12 @@ export function readData(options: ControllerOptions): void {
     async (c) => {
       const user = c.get("user");
       const params = c.req.valid("param");
-      const command = UserDataMapper.toFindDataCommand(user, params);
+      const command = UserDataMapper.toReadDataCommand(user, params);
 
       return pipe(
         enforceDataOwnership(user, command.document, command.collection),
-        E.flatMap(() => DataService.readRecords(c.env, command)),
-        E.map((documents) => documents as OwnedDocumentBase[]),
+        E.flatMap(() => DataService.readRecord(c.env, command)),
+        E.map((documents) => documents as OwnedDocumentBase),
         E.map((document) => UserDataMapper.toReadDataResponse(document)),
         E.map((response) => c.json(response)),
         handleTaggedErrors(c),

--- a/src/users/users.controllers.ts
+++ b/src/users/users.controllers.ts
@@ -9,7 +9,11 @@ import {
   OpenApiSpecCommonErrorResponses,
   OpenApiSpecEmptySuccessResponses,
 } from "#/common/openapi";
-import { checkRevokeAccess, enforceDataOwnership } from "#/common/ownership";
+import {
+  checkGrantAccess,
+  checkRevokeAccess,
+  enforceDataOwnership,
+} from "#/common/ownership";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { UpdateDataResponse } from "#/data/data.dto";
@@ -286,6 +290,10 @@ export function grantAccess(options: ControllerOptions): void {
 
       return pipe(
         enforceDataOwnership(user, command.document, command.collection),
+        E.flatMap(() => BuildersService.find(c.env, command.acl.grantee)),
+        E.flatMap((builder) =>
+          checkGrantAccess(builder, command.collection, command.acl),
+        ),
         E.flatMap(() => UserService.grantAccess(c.env, command)),
         E.map((_result) => GrantAccessToDataResponse),
         handleTaggedErrors(c),

--- a/src/users/users.dto.ts
+++ b/src/users/users.dto.ts
@@ -93,9 +93,7 @@ const OwnedDataDto = z
   // Allow all keys through since each collection will follow a different schema
   .passthrough();
 
-export const ReadDataResponse = ApiSuccessResponse(
-  z.array(OwnedDataDto),
-).openapi({
+export const ReadDataResponse = ApiSuccessResponse(OwnedDataDto).openapi({
   ref: "ReadDataResponse",
 });
 export type ReadDataResponse = z.infer<typeof ReadDataResponse>;

--- a/src/users/users.mapper.ts
+++ b/src/users/users.mapper.ts
@@ -1,6 +1,6 @@
 import { UUID } from "mongodb";
 import { Did } from "#/common/types";
-import type { OwnedDocumentBase } from "#/data/data.types";
+import type { OwnedDocumentBase, ReadDataCommand } from "#/data/data.types";
 import type {
   DeleteDocumentRequestParams,
   GrantAccessToDataRequest,
@@ -20,7 +20,6 @@ import type {
   DeleteUserDataCommand,
   GrantAccessToDataCommand,
   ReadDataAclCommand,
-  ReadDataCommand,
   RevokeAccessToDataCommand,
   UpdateUserDataCommand,
   UserDocument,
@@ -158,9 +157,9 @@ export const UserDataMapper = {
   },
 
   /**
-   * Convert read params to find command.
+   * Convert read params to read command.
    */
-  toFindDataCommand(
+  toReadDataCommand(
     user: UserDocument,
     body: ReadDataRequestParams,
   ): ReadDataCommand {
@@ -175,16 +174,16 @@ export const UserDataMapper = {
   },
 
   /**
-   * Convert documents to read response.
+   * Convert document to read response.
    */
-  toReadDataResponse(documents: OwnedDocumentBase[]): ReadDataResponse {
+  toReadDataResponse(document: OwnedDocumentBase): ReadDataResponse {
     return {
-      data: documents.map((d) => ({
-        ...d,
-        _id: d._id.toString(),
-        _created: d._created.toISOString(),
-        _updated: d._updated.toISOString(),
-      })),
+      data: {
+        ...document,
+        _id: document._id.toString(),
+        _created: document._created.toISOString(),
+        _updated: document._updated.toISOString(),
+      },
     };
   },
 } as const;

--- a/src/users/users.types.ts
+++ b/src/users/users.types.ts
@@ -1,11 +1,7 @@
 import type { UUID } from "mongodb";
 import type { DocumentBase } from "#/common/mongo";
 import type { Did } from "#/common/types";
-import type {
-  DeleteDataCommand,
-  FindDataCommand,
-  UpdateDataCommand,
-} from "#/data/data.types";
+import type { DeleteDataCommand, UpdateDataCommand } from "#/data/data.types";
 import type { UserDataLogs } from "#/users/users.dto";
 
 /**
@@ -41,13 +37,6 @@ export type DataDocumentReference = {
 export type UserDocument = DocumentBase<Did> & {
   data: DataDocumentReference[];
   log: UserDataLogs[];
-};
-
-/**
- * Read data command.
- */
-export type ReadDataCommand = FindDataCommand & {
-  document: UUID;
 };
 
 /**

--- a/tests/owned-data.test.ts
+++ b/tests/owned-data.test.ts
@@ -321,11 +321,10 @@ describe("owned-data.test.ts", () => {
       .readData(c, collection.id.toString(), documentId.toString())
       .expectSuccess();
 
-    const userData = result.data[0];
-    expect(userData?._acl).toHaveLength(1);
-    expect(userData?._acl[0]?.read).toBe(true);
-    expect(userData?._acl[0]?.write).toBe(false);
-    expect(userData?._acl[0]?.execute).toBe(false);
+    expect(result.data._acl).toHaveLength(1);
+    expect(result.data._acl[0]?.read).toBe(true);
+    expect(result.data._acl[0]?.write).toBe(false);
+    expect(result.data._acl[0]?.execute).toBe(false);
   });
 
   it("user cannot access data they are not the owner of", async ({ c }) => {
@@ -397,11 +396,10 @@ describe("owned-data.test.ts", () => {
       .readData(c, collection.id.toString(), documentId.toString())
       .expectSuccess();
 
-    const userData = result.data[0];
-    expect(userData?._acl).toHaveLength(2);
-    expect(userData?._acl[1]?.read).toBe(false);
-    expect(userData?._acl[1]?.write).toBe(false);
-    expect(userData?._acl[1]?.execute).toBe(false);
+    expect(result.data._acl).toHaveLength(2);
+    expect(result.data._acl[1]?.read).toBe(false);
+    expect(result.data._acl[1]?.write).toBe(false);
+    expect(result.data._acl[1]?.execute).toBe(false);
   });
 
   it("can revoke access", async ({ c }) => {
@@ -427,6 +425,6 @@ describe("owned-data.test.ts", () => {
       .readData(c, collection.id.toString(), documentId.toString())
       .expectSuccess();
 
-    expect(result.data[0]?._acl).toHaveLength(1);
+    expect(result.data._acl).toHaveLength(1);
   });
 });


### PR DESCRIPTION
closes #247

On bullet 1: imo I think we don't need to do anything, groupByOwner is already filtering, but if you have another approach, I can implement it.

On bullet 3: I have also implemented a policy for grantAccess, I think acl with all values ​​in false doesn't make sense for the collection owner.